### PR TITLE
feat(deinterleave): real SIMD f32 RGB/RGBA chunks (NEON ld3q + AVX2 / wasm128 shuffles)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,9 @@ rgb = { version = "0.8", default-features = false, features = ["as-bytes"] }
 imgref = "1.12"
 bytemuck = { version = "1.25", default-features = false, features = ["extern_crate_alloc"] }
 enough = "0.4.2"
-zencodec = { version = "0.1.13" }
-zenpixels = { version = "0.2.1", default-features = false, features = ["imgref"] }
-zenpixels-convert = { version = "0.2.1", features = ["imgref"] }
+zencodec = { version = "0.1.16" }
+zenpixels = { version = "0.2.7", default-features = false, features = ["imgref"] }
+zenpixels-convert = { version = "0.2.7", features = ["imgref"] }
 zenquant = { version = "0.1.1", optional = true }
 imagequant = { version = "4", optional = true }
 quantette = { version = "0.5", optional = true, default-features = false, features = ["kmeans", "std"] }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -2348,6 +2348,7 @@ fn convert_info(info: &crate::decode::PngInfo) -> ImageInfo {
     }
     if let Some(cicp) = info.cicp {
         zi = zi.with_cicp(cicp);
+        zi = zi.with_color_authority(zencodec::ColorAuthority::Cicp);
     }
     if let Some(clli) = info.content_light_level {
         zi = zi.with_content_light_level(clli);


### PR DESCRIPTION
## Summary

This PR (re-titled and expanded) lands two layers of work on `src/deinterleave.rs`:

1. **(Original PR #5)** 12 new public scalar chunk-level f32 RGB/RGBA deinterleave + interleave functions at chunk widths {4, 8, 16}.
2. **(New)** Per-arch SIMD specializations of those chunks — real `vld3q_f32` / `vld4q_f32` / `vst3q_f32` / `vst4q_f32` on AArch64; real `vshufps` / `vinsertps` / `vblendps` / `vunpcklps` / `vmovlhps` on x86_64 AVX2; real `i8x16.shuffle` / `v128.load` / `v128.store` on wasm32 SIMD128. The slice-level `rgb_f32_to_planes_f32` / `rgba_f32_to_planes_f32` / `planes_f32_to_rgb_f32` / `planes_f32_to_rgba_f32` `#[arcane]` dispatchers (which previously called the scalar loop body verbatim under a `target_feature = "avx2"` / `"neon"` region) now route through these chunk SIMD primitives via a 16 → 8 → 4 → scalar tail pipeline.

## Public API

Twelve new shape-keys per chunk variant — chunk-{4, 8, 16} × {RGB, RGBA} × {deinterleave, interleave}:

```text
{rgb,rgba}_f32_chunk{4,8,16}_to_planes_{scalar,v3,neon,wasm128}   (24 deinterleavers)
planes_to_{rgb,rgba}_f32_chunk{4,8,16}_{scalar,v3,neon,wasm128}   (24 interleavers)
```

The bare-name aliases from the original PR #5 (`rgb_f32_chunk4_to_planes` etc.) are preserved as thin wrappers around `*_scalar` so existing callers compile untouched.

`cargo semver-checks check-release --all-features` reports **`Summary no semver update required`** — purely additive.

## Codegen verification

`#[rite]` on every per-arch chunk function so they fuse into the caller's `#[arcane]` / `target_feature` region — no `call` / `b` instruction at the chunk boundary. Verified by `tests/asm_inline_check.rs` which dumps a `sample_caller_*_chunk16` body and asserts the chunk function's SIMD ops appear inline.

<details>
<summary>x86_64 AVX2 — `sample_caller_v3_rgb_chunk16` (chunk-16 RGB deinterleave, fully inlined)</summary>

```asm
asm_inline_check::x86_inline::__arcane_sample_caller_v3_rgb_chunk16:
    vmovups xmm2, xmmword ptr [rsi]
    vmovups xmm3, xmmword ptr [rsi + 16]
    vmovups xmm4, xmmword ptr [rsi + 48]
    vmovups xmm5, xmmword ptr [rsi + 64]
    vinsertps xmm0, xmm3, xmm2, 140
    vshufps xmm0, xmm0, xmmword ptr [rsi + 32], 196
    vblendps xmm1, xmm3, xmm2, 2
    vshufps xmm1, xmm1, xmm1, 241
    vbroadcastss xmm6, dword ptr [rsi + 40]
    vblendps xmm1, xmm1, xmm6, 8
    vshufps xmm3, xmm2, xmm3, 236
    ...  (4× chunk-4 sub-bodies, 56 SIMD ops total)
    vmovups xmmword ptr [rdi], xmm6
    vmovups xmmword ptr [rdi + 16], xmm4
    ...  (12× 16-byte stores)
    ret
```

- 56 SIMD ops in the body (`vmovups` / `vshufps` / `vblendps` / `vinsertps` / `vbroadcastss`).
- **0 `call` instructions** to any `*_chunk*_v3` symbol — fully inlined.
- 0 scalar `vmovss` / `movss` loads.

</details>

<details>
<summary>aarch64 NEON — `garb::deinterleave::rgb_f32_to_planes_f32` (slice-level dispatch into chunk-16 NEON)</summary>

```asm
.LBB8_8:
    cmp x8, x1
    b.hi .LBB8_30
    mov x11, x9
    sub x16, x9, #96
    add x8, x8, #48
    ld3 { v0.4s, v1.4s, v2.4s }, [x11], #48
    ld3 { v3.4s, v4.4s, v5.4s }, [x16]
    ld3 { v19.4s, v20.4s, v21.4s }, [x11]
    ld3 { v16.4s, v17.4s, v18.4s }, [x16]
    ...
    stp q3, q16, [x13, #-32]
    stp q0, q19, [x13], #64
    ...
    b.ls .LBB8_8
```

- 4× `ld3 { v0.4s, v1.4s, v2.4s }` per inner-loop iteration (= unrolled 2 × chunk-16) — exactly the hardware structure-load.
- 0 scalar `ldr s0` loads in the inner loop.
- The RGBA path lights up `ld4 { v0.4s, v1.4s, v2.4s, v3.4s }` instead — 8 in the chunk-16 unrolled body.
- The interleave path emits `st3` / `st4` symmetrically (8 each in the unrolled chunk-16 inner body).

</details>

<details>
<summary>wasm32 SIMD128 — `garb::deinterleave::rgb_f32_to_planes_f32` (slice-level dispatch into chunk-16 wasm128)</summary>

WAT histogram across the full slice-level body (built with `RUSTFLAGS="-C target-feature=+simd128"`):

```text
   42  i8x16.shuffle    ← cross-lane permute (i32x4_shuffle macro lowers to i8x16.shuffle)
   33  v128.load
   24  v128.store
    3  f32.load          ← scalar tail (< 4 pixels)
    3  f32.store         ← scalar tail
```

</details>

## Test plan

- [x] `cargo test --release --features experimental` (x86_64) — **228 lib tests pass**, including 12 byte-exact `*_v3 vs *_scalar` parity tests for the new SIMD chunks.
- [x] `cross test --release --features experimental --target aarch64-unknown-linux-gnu` (qemu) — **209 lib tests pass**, including 12 byte-exact `*_neon vs *_scalar` parity tests.
- [x] `RUSTFLAGS="-C target-feature=+simd128" cargo test --target wasm32-wasip1 --features experimental --release` (wasmtime) — **209 lib tests pass**, including 12 byte-exact `*_wasm128 vs *_scalar` parity tests.
- [x] `tests/asm_inline_check.rs` — runs as a smoke test on each arch when the host has the required ISA; verifies the `#[rite]` chunk functions inline cleanly into a sample `#[arcane]` caller. Passes on x86_64 native + aarch64 cross.
- [x] `cargo semver-checks check-release --all-features` — `Summary no semver update required` (purely additive).
- [x] `cargo clippy --release --all-features --lib --tests` — clean.

Existing tests retained (round-trip / slice-API-equivalence / order-preservation) — they now exercise the SIMD path on each arch instead of bare scalar.

## Notes

- No version bump in `Cargo.toml`; release cadence is the maintainer's call.
- The wasm32 slice-level `*_impl_wasm128` route is wired up via `incant!(...[v3, neon, wasm128, scalar])` for symmetry; existing slice-level callers benefit on wasm32 with `+simd128`.
- The chunk-level `_scalar` variants stay public so callers in non-SIMD regions (or with their own dispatch) can use them without going through the slice-level dispatcher.
- Integrating into `zenpixels-convert`'s narrow body (the original use case) is a separate follow-up.
