### PR TITLE
perf: memchr for text-chunk null search + probe redundancy finding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ imagequant = { version = "4", optional = true }
 quantette = { version = "0.5", optional = true, default-features = false, features = ["kmeans", "std"] }
 whereat = "0.1.4"
 zenflate = { version = "0.3.2" }
+memchr = { version = "2.8.0", default-features = false }
 archmage = { version = "0.9.14", default-features = false, features = ["macros", "std"] }
 safe_unaligned_simd = { version = "0.2.5", default-features = false }
 linear-srgb = "0.6.5"

--- a/src/chunk/ancillary.rs
+++ b/src/chunk/ancillary.rs
@@ -274,7 +274,7 @@ impl PngAncillary {
     /// Parse iCCP chunk: null-terminated profile name, compression method, compressed data.
     fn parse_iccp(&mut self, data: &[u8]) -> crate::error::Result<()> {
         // Find null terminator for profile name
-        let null_pos = data.iter().position(|&b| b == 0).ok_or_else(|| {
+        let null_pos = memchr::memchr(0, data).ok_or_else(|| {
             at!(PngError::Decode(
                 "iCCP: missing profile name terminator".into()
             ))
@@ -338,14 +338,14 @@ impl PngAncillary {
         let rest = &rest[2..];
 
         // Skip language tag (null-terminated)
-        let lang_end = rest.iter().position(|&b| b == 0).unwrap_or(rest.len());
+        let lang_end = memchr::memchr(0, rest).unwrap_or(rest.len());
         if lang_end >= rest.len() {
             return;
         }
         let rest = &rest[lang_end + 1..];
 
         // Skip translated keyword (null-terminated)
-        let trans_end = rest.iter().position(|&b| b == 0).unwrap_or(rest.len());
+        let trans_end = memchr::memchr(0, rest).unwrap_or(rest.len());
         if trans_end >= rest.len() {
             return;
         }
@@ -372,7 +372,7 @@ impl PngAncillary {
 
     /// Parse tEXt chunk: keyword\0text (Latin-1).
     fn parse_text(&mut self, data: &[u8], compressed: bool) {
-        if let Some(null_pos) = data.iter().position(|&b| b == 0) {
+        if let Some(null_pos) = memchr::memchr(0, data) {
             let keyword = &data[..null_pos];
             let text = &data[null_pos + 1..];
             if !keyword.is_empty() && keyword.len() <= 79 {
@@ -390,7 +390,7 @@ impl PngAncillary {
 
     /// Parse zTXt chunk: keyword\0compression_method + compressed_text.
     fn parse_ztxt(&mut self, data: &[u8]) {
-        let Some(null_pos) = data.iter().position(|&b| b == 0) else {
+        let Some(null_pos) = memchr::memchr(0, data) else {
             return;
         };
         let keyword = &data[..null_pos];

--- a/src/detect.rs
+++ b/src/detect.rs
@@ -239,7 +239,7 @@ pub fn probe(data: &[u8]) -> Result<PngProbe, ProbeError> {
                 // Parse tEXt: keyword\0value
                 if chunk_data_end > chunk_data_start {
                     let chunk_bytes = &data[chunk_data_start..chunk_data_end];
-                    if let Some(null_pos) = chunk_bytes.iter().position(|&b| b == 0) {
+                    if let Some(null_pos) = memchr::memchr(0, chunk_bytes) {
                         let keyword = core::str::from_utf8(&chunk_bytes[..null_pos]).ok();
                         let value_bytes = &chunk_bytes[null_pos + 1..];
                         let value = core::str::from_utf8(value_bytes).ok();
@@ -257,7 +257,7 @@ pub fn probe(data: &[u8]) -> Result<PngProbe, ProbeError> {
                 // Parse iTXt: keyword\0compression_flag\0method\0lang\0translated_kw\0text
                 if chunk_data_end > chunk_data_start {
                     let chunk_bytes = &data[chunk_data_start..chunk_data_end];
-                    if let Some(null_pos) = chunk_bytes.iter().position(|&b| b == 0) {
+                    if let Some(null_pos) = memchr::memchr(0, chunk_bytes) {
                         let keyword = core::str::from_utf8(&chunk_bytes[..null_pos]).ok();
                         if let Some(kw) = keyword
                             && (kw == "Software" || kw == "Creator")
@@ -268,10 +268,10 @@ pub fn probe(data: &[u8]) -> Result<PngProbe, ProbeError> {
                             if rest.len() >= 2 {
                                 let after_method = &rest[2..];
                                 // Skip lang_tag\0
-                                if let Some(p1) = after_method.iter().position(|&b| b == 0) {
+                                if let Some(p1) = memchr::memchr(0, after_method) {
                                     let after_lang = &after_method[p1 + 1..];
                                     // Skip translated_keyword\0
-                                    if let Some(p2) = after_lang.iter().position(|&b| b == 0) {
+                                    if let Some(p2) = memchr::memchr(0, after_lang) {
                                         let text = &after_lang[p2 + 1..];
                                         if let Ok(s) = core::str::from_utf8(text) {
                                             creating_tool = Some(String::from(s));


### PR DESCRIPTION
## Summary

- Replace scalar `.iter().position(|&b| b == 0)` with `memchr::memchr(0, ...)` in
  iCCP/tEXt/iTXt/zTXt/XMP parsers (`src/chunk/ancillary.rs`, `src/detect.rs`).
- Adds `memchr = "2.8.0"` as a direct dep (no_std-compatible).
- Audit finding on `detect::probe` redundancy — documented below, **no API change
  in this PR** pending maintainer decision.

## Bench — memchr (detect::probe on synthetic PNGs)

| scenario                | baseline | memchr   | delta  |
|-------------------------|----------|----------|--------|
| 4 tEXt × 64B            |   74 ns  |   72 ns  | noise  |
| 32 tEXt × 512B          |  621 ns  |  602 ns  | -3%    |
| 128 tEXt × 4KB          | 9636 ns  | 8514 ns  | -12%   |
| real PNGs (qoi corpus)  |  ~1.0 µs |  ~1.1 µs | noise (chunk traversal dominates) |

memchr's SIMD pays off with longer null-searches. Short keyword scans see no
measurable change; long value/ICC/XMP blobs benefit.

## Probe redundancy audit (informational)

Investigating the same pattern fixed in zenjpeg, I traced the PNG decode path:

`PngDecoder::decode()` (codec.rs:1699) runs **three full chunk-level passes per decode**:

1. `crate::decode::probe(&self.data)` (L1713) — parses IHDR + ancillaries for
   dimension bounds check.
2. `crate::decode::decode(&self.data, ...)` (L1718) — full decode; internally
   re-parses every chunk.
3. `crate::detect::probe(&self.data)` (L1727) — scans all chunks again to
   produce `PngProbe` attached via `with_source_encoding_details`.

Step 3 runs unconditionally. Similar redundancy in `DecoderConfig::probe` (L1582),
`push_decoder_native` path (L1713), and streaming decoder (L1982).

`PngProbe` fields mostly duplicate `PngInfo`:
- **Duplicated**: width, height, color_type, bit_depth, has_alpha, interlaced,
  sequence, palette_size, creating_tool (PngAncillary already parses Software/
  Creator via `parse_text`), IDAT total (the row decoder tracks this).
- **Unique**: `compression_ratio`, `CompressionAssessment`, `Vec<Recommendation>`,
  `raw_data_size`. These are assessment heuristics, not decoder output.

### Proposed fix (NOT in this PR)

Gate the `detect::probe` call behind an opt-in flag:
`PngDecoderConfig::with_source_encoding_details(bool)` (default `false`).
This is a public-API addition and waits on maintainer approval. A future
follow-up could also derive `PngProbe` from decoder state to fold all three
passes into one, but that's a larger refactor.

## Test plan

- [x] `cargo test --release -p zenpng --all-targets` — 588 passed, 8 ignored
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Microbench: synthetic PNGs with inflated tEXt chunks, real PNGs from
      `codec-corpus/qoi-benchmark/screenshot_web/`