### PR TITLE
fix: cap APNG cumulative frame memory and text-chunk accumulation

### DIFF
--- a/src/chunk/ancillary.rs
+++ b/src/chunk/ancillary.rs
@@ -1174,4 +1174,84 @@ mod tests {
         assert_eq!(anc.text_chunks.len(), 1);
         assert_eq!(anc.text_chunks[0].text, "post-IDAT text");
     }
+
+    // ---- Security: text-chunk caps (H2 regression tests) ----
+
+    /// Build a tEXt chunk payload: keyword\0text.
+    fn text_chunk(keyword: &[u8], text: &[u8]) -> Vec<u8> {
+        let mut data = Vec::with_capacity(keyword.len() + 1 + text.len());
+        data.extend_from_slice(keyword);
+        data.push(0);
+        data.extend_from_slice(text);
+        data
+    }
+
+    #[test]
+    fn text_chunk_count_capped_at_max() {
+        // Push MAX_TEXT_CHUNKS + 50 distinct tEXt chunks; only MAX_TEXT_CHUNKS
+        // should be retained. Empty-keyword guard requires non-empty kw.
+        let mut anc = PngAncillary::default();
+        for i in 0..(MAX_TEXT_CHUNKS + 50) {
+            let kw = format!("Key{i}");
+            let data = text_chunk(kw.as_bytes(), b"v");
+            anc.collect(&make_chunk(b"tEXt", &data)).unwrap();
+        }
+        assert_eq!(anc.text_chunks.len(), MAX_TEXT_CHUNKS);
+    }
+
+    #[test]
+    fn creating_tool_extracted_before_text_cap() {
+        // Even after MAX_TEXT_CHUNKS is exhausted, the first matching
+        // Software/Creator/Comment keyword must still populate creating_tool
+        // for detect::probe parity.
+        let mut anc = PngAncillary::default();
+        // Fill text_chunks up to the cap with non-matching keywords first.
+        for i in 0..MAX_TEXT_CHUNKS {
+            let kw = format!("Other{i}");
+            let data = text_chunk(kw.as_bytes(), b"v");
+            anc.collect(&make_chunk(b"tEXt", &data)).unwrap();
+        }
+        assert_eq!(anc.text_chunks.len(), MAX_TEXT_CHUNKS);
+        assert!(anc.creating_tool.is_none());
+        // Now a Software chunk arrives past the cap: chunk is dropped, but
+        // creating_tool is still extracted.
+        let data = text_chunk(b"Software", b"zenpng-test/1.0");
+        anc.collect(&make_chunk(b"tEXt", &data)).unwrap();
+        assert_eq!(anc.text_chunks.len(), MAX_TEXT_CHUNKS);
+        assert_eq!(anc.creating_tool.as_deref(), Some("zenpng-test/1.0"));
+    }
+
+    #[test]
+    fn ztxt_compressed_budget_caps_consumption() {
+        // Build a zTXt chunk with ~64 KiB of compressed payload. The first 64
+        // chunks consume 4 MiB; the 65th must be dropped without decompression
+        // (so text_compressed_bytes_consumed stops growing).
+        let mut anc = PngAncillary::default();
+        // Construct a minimal valid zTXt: keyword\0compression_method(0)+payload.
+        // Use raw zlib-compressed bytes of "x" so each payload is small but
+        // decompression succeeds when budget allows.
+        let mut z = zenflate::Compressor::new(zenflate::CompressionLevel::fast());
+        let payload = vec![b'x'; 65_000];
+        let mut buf = vec![0u8; 70_000];
+        let n = z.zlib_compress(&payload, &mut buf, Unstoppable).unwrap();
+        buf.truncate(n);
+
+        let mut chunk_data = Vec::new();
+        chunk_data.extend_from_slice(b"K");
+        chunk_data.push(0);
+        chunk_data.push(0); // compression_method = zlib
+        chunk_data.extend_from_slice(&buf);
+
+        // Feed chunks until the cap is exceeded, then one more.
+        let per_chunk = buf.len() as u64;
+        let need = MAX_TEXT_COMPRESSED_BYTES.div_ceil(per_chunk) as usize;
+        for _ in 0..need {
+            anc.collect(&make_chunk(b"zTXt", &chunk_data)).unwrap();
+        }
+        let consumed_before = anc.text_compressed_bytes_consumed;
+        assert!(consumed_before <= MAX_TEXT_COMPRESSED_BYTES);
+        // One more chunk should be skipped without consuming budget.
+        anc.collect(&make_chunk(b"zTXt", &chunk_data)).unwrap();
+        assert_eq!(anc.text_compressed_bytes_consumed, consumed_before);
+    }
 }

--- a/src/chunk/ancillary.rs
+++ b/src/chunk/ancillary.rs
@@ -102,6 +102,20 @@ impl FrameControl {
     }
 }
 
+/// Maximum number of text chunks (tEXt + zTXt + iTXt) we accumulate before
+/// silently dropping further chunks. PNG/APNG files in the wild hold a handful
+/// of `Software`/`Comment`/`Description` entries; an attacker can stuff a small
+/// PNG with millions of zTXt chunks (each ~30 bytes) where every chunk forces
+/// a 1 MiB transient zlib output buffer and a permanent decompressed `String`.
+/// Capping at 256 entries keeps real-world metadata available without letting
+/// attacker text dominate decode peak memory.
+pub(crate) const MAX_TEXT_CHUNKS: usize = 256;
+
+/// Maximum total compressed bytes we will pass through zlib decompression for
+/// zTXt/iTXt text payloads across the whole file. Bounds aggregate decompress
+/// CPU time and transient buffer usage independent of `MAX_TEXT_CHUNKS`.
+pub(crate) const MAX_TEXT_COMPRESSED_BYTES: u64 = 4 * 1024 * 1024;
+
 /// Collected ancillary chunk data.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct PngAncillary {
@@ -151,6 +165,11 @@ pub(crate) struct PngAncillary {
     /// text chunks are parsed so [`crate::detect::PngProbe::from_info`]
     /// produces the same value without a second scan.
     pub creating_tool: Option<String>,
+
+    /// Running total of compressed bytes fed into zlib decompression for
+    /// zTXt/iTXt chunks. Capped by [`MAX_TEXT_COMPRESSED_BYTES`]; once exceeded
+    /// further compressed text payloads are dropped without decompression.
+    pub text_compressed_bytes_consumed: u64,
 }
 
 impl PngAncillary {
@@ -349,7 +368,15 @@ impl PngAncillary {
                 self.xmp = Some(text_data.to_vec());
             }
         } else if compression_flag == 1 {
-            // zlib compressed
+            // zlib compressed — share the per-file compressed-text budget with
+            // zTXt to bound aggregate decompression CPU/transient memory.
+            let new_consumed = self
+                .text_compressed_bytes_consumed
+                .saturating_add(text_data.len() as u64);
+            if new_consumed > MAX_TEXT_COMPRESSED_BYTES {
+                return;
+            }
+            self.text_compressed_bytes_consumed = new_consumed;
             let max_output = 4 * 1024 * 1024; // 4 MB limit for XMP
             let mut output = vec![0u8; max_output];
             let mut decompressor = zenflate::Decompressor::new();
@@ -420,6 +447,11 @@ impl PngAncillary {
                 {
                     self.creating_tool = Some(val.clone());
                 }
+                if self.text_chunks.len() >= MAX_TEXT_CHUNKS {
+                    // Silently drop further text chunks; creating_tool above
+                    // still gets the first match for detect::probe parity.
+                    return;
+                }
                 self.text_chunks.push(TextChunk {
                     keyword: kw,
                     text: val,
@@ -450,6 +482,20 @@ impl PngAncillary {
         if compressed.is_empty() {
             return;
         }
+
+        // Skip decompression entirely once we've hit either cap. Bounds the
+        // attacker's ability to drive transient 1-MiB zlib output buffers and
+        // permanent decompressed-text storage via many small zTXt chunks.
+        if self.text_chunks.len() >= MAX_TEXT_CHUNKS {
+            return;
+        }
+        let new_consumed = self
+            .text_compressed_bytes_consumed
+            .saturating_add(compressed.len() as u64);
+        if new_consumed > MAX_TEXT_COMPRESSED_BYTES {
+            return;
+        }
+        self.text_compressed_bytes_consumed = new_consumed;
 
         // Decompress
         let max_output = 1024 * 1024; // 1 MB limit for text

--- a/src/decoder/apng.rs
+++ b/src/decoder/apng.rs
@@ -506,6 +506,14 @@ pub(crate) fn decode_apng_composed(
     // Previous frame's fctl (for applying dispose_op after yielding)
     let mut prev_fctl: Option<FrameControl> = None;
 
+    // Track cumulative frame memory. `config.max_memory_bytes` only governs the
+    // canvas allocation; without an additional cap, an attacker-crafted APNG
+    // with up to 65535 frames at canvas-sized RGBA can request many TiB of
+    // heap via `frames.push` (each frame is a full canvas-sized pixel copy).
+    // Apply the same `max_memory_bytes` budget to the cumulative `frames` Vec.
+    let per_frame_bytes = canvas_bytes as u64;
+    let mut total_frame_bytes: u64 = 0;
+
     while let Some(frame) = decoder.next_frame(cancel)? {
         // Apply dispose_op from the PREVIOUS frame before compositing this one
         if let Some(pfctl) = prev_fctl {
@@ -520,6 +528,17 @@ pub(crate) fn decode_apng_composed(
         // Promote subframe pixels to RGBA and composite onto canvas
         let subframe_rgba = promote_to_rgba(&frame.pixels, is_16bit);
         composite_frame(&frame.fctl, &subframe_rgba, &mut canvas, canvas_w, is_16bit);
+
+        // Enforce cumulative-frame memory budget BEFORE allocating the next
+        // frame's canvas-sized pixel copy.
+        if let Some(max_mem) = config.max_memory_bytes {
+            total_frame_bytes = total_frame_bytes.saturating_add(per_frame_bytes);
+            if total_frame_bytes > max_mem {
+                return Err(at!(PngError::LimitExceeded(
+                    "cumulative APNG frame memory exceeds limit".into(),
+                )));
+            }
+        }
 
         // Build PixelBuffer directly from canvas (single copy, no intermediate Vec)
         let pixels = canvas_to_pixel_data(&canvas, canvas_w, canvas_h, is_16bit);

--- a/src/decoder/postprocess.rs
+++ b/src/decoder/postprocess.rs
@@ -95,33 +95,56 @@ pub(crate) fn scale_to_8bit(value: u8, bit_depth: u8) -> u8 {
 }
 
 /// Unpack sub-8-bit grayscale pixels from a packed row.
+///
+/// `raw` must hold at least `ceil(width × bit_depth / 8)` bytes; callers in
+/// tree (`post_process_row` and the interlace path) always size the row to
+/// match. The defensive `break` below converts any future caller that
+/// violates the invariant into a partial-row truncation rather than a panic.
 fn unpack_sub_byte_gray(raw: &[u8], width: usize, bit_depth: u8, out: &mut Vec<u8>) {
     let pixels_per_byte = 8 / bit_depth as usize;
     let mask = (1u8 << bit_depth) - 1;
 
     for x in 0..width {
         let byte_idx = x / pixels_per_byte;
+        let Some(byte) = raw.get(byte_idx) else { break };
         let bit_offset = (pixels_per_byte - 1 - x % pixels_per_byte) * bit_depth as usize;
-        let value = (raw[byte_idx] >> bit_offset) & mask;
+        let value = (byte >> bit_offset) & mask;
         out.push(scale_to_8bit(value, bit_depth));
     }
 }
 
 /// Unpack sub-8-bit indexed pixels from a packed row.
+///
+/// `raw` must hold at least `ceil(width × bit_depth / 8)` bytes; see the doc
+/// on [`unpack_sub_byte_gray`] for the invariant and the rationale for the
+/// `break`-on-short-input fallback.
 fn unpack_sub_byte_indexed(raw: &[u8], width: usize, bit_depth: u8, out: &mut Vec<u8>) {
     let pixels_per_byte = 8 / bit_depth as usize;
     let mask = (1u8 << bit_depth) - 1;
 
     for x in 0..width {
         let byte_idx = x / pixels_per_byte;
+        let Some(byte) = raw.get(byte_idx) else { break };
         let bit_offset = (pixels_per_byte - 1 - x % pixels_per_byte) * bit_depth as usize;
-        let index = (raw[byte_idx] >> bit_offset) & mask;
+        let index = (byte >> bit_offset) & mask;
         out.push(index);
     }
 }
 
 /// Post-process a raw unfiltered row into output pixels.
 /// Returns the output pixel data for this row.
+///
+/// # Invariant
+///
+/// `raw` must contain at least `ceil(ihdr.width × ihdr.channels × ihdr.bit_depth / 8)`
+/// bytes — the unfiltered scanline length the row decoder produces. The
+/// in-tree callers (`RowDecoder` and the interlace pass loop) always supply
+/// a row sized this way. Sub-byte unpacking guards against shorter input
+/// with an early break, but the truecolor / palette-byte branches index
+/// `raw` directly and will panic on a too-short row. Treat that as an
+/// internal-API contract: violating it is a refactor bug, not an attacker
+/// surface, since untrusted input flows in via `decode_png` which sizes
+/// `raw` from the row decoder.
 pub(crate) fn post_process_row(
     raw: &[u8],
     ihdr: &Ihdr,

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -746,22 +746,30 @@ fn encode_raw_with_stats(
                 ),
             }
         }
-        (ColorType::Rgb, BitDepth::Eight) => match crate::optimize::optimize_rgb8(bytes, w, h, &config.downcast) {
-            crate::optimize::OptimalEncoding::Truecolor {
-                bytes: ob,
-                color_type: ct,
-                bit_depth: bd,
-                trns,
-            } => (Some(ob), ct, bd, trns),
-            _ => (
-                None,
-                color_type.to_png_byte(),
-                bit_depth.to_png_byte(),
-                None,
-            ),
-        },
+        (ColorType::Rgb, BitDepth::Eight) => {
+            match crate::optimize::optimize_rgb8(bytes, w, h, &config.downcast) {
+                crate::optimize::OptimalEncoding::Truecolor {
+                    bytes: ob,
+                    color_type: ct,
+                    bit_depth: bd,
+                    trns,
+                } => (Some(ob), ct, bd, trns),
+                _ => (
+                    None,
+                    color_type.to_png_byte(),
+                    bit_depth.to_png_byte(),
+                    None,
+                ),
+            }
+        }
         (_, BitDepth::Sixteen) => {
-            match crate::optimize::optimize_16bit(bytes, w, h, color_type.to_png_byte(), &config.downcast) {
+            match crate::optimize::optimize_16bit(
+                bytes,
+                w,
+                h,
+                color_type.to_png_byte(),
+                &config.downcast,
+            ) {
                 crate::optimize::OptimalEncoding::Truecolor {
                     bytes: ob,
                     color_type: ct,
@@ -973,7 +981,12 @@ mod tests {
         // 4 RGBA pixels, all opaque, all gray — would normally become Gray8.
         // With downcast disabled, must stay RGBA8.
         let pixels: Vec<Rgba<u8>> = (0..4)
-            .map(|i| Rgba { r: i * 30, g: i * 30, b: i * 30, a: 255 })
+            .map(|i| Rgba {
+                r: i * 30,
+                g: i * 30,
+                b: i * 30,
+                a: 255,
+            })
             .collect();
         let img = Img::new(pixels, 4, 1);
         let config = EncodeConfig::default()
@@ -984,7 +997,10 @@ mod tests {
         let decoded =
             crate::decode(&encoded, &crate::PngDecodeConfig::default(), &Unstoppable).unwrap();
         // PNG color_type 6 = RGBA, NOT gray.
-        assert_eq!(decoded.info.color_type, 6, "downcast disabled — must stay RGBA");
+        assert_eq!(
+            decoded.info.color_type, 6,
+            "downcast disabled — must stay RGBA"
+        );
     }
 
     #[test]
@@ -1027,12 +1043,8 @@ mod tests {
             &Unstoppable,
         )
         .unwrap();
-        let decoded = crate::decode(
-            &encoded,
-            &crate::PngDecodeConfig::default(),
-            &Unstoppable,
-        )
-        .unwrap();
+        let decoded =
+            crate::decode(&encoded, &crate::PngDecodeConfig::default(), &Unstoppable).unwrap();
         // After downcast, the file should NOT carry P3 cICP.
         assert!(
             decoded.info.cicp.is_none() || decoded.info.cicp == Some(Cicp::SRGB),
@@ -1046,7 +1058,12 @@ mod tests {
         // Same buffer, gamut_downcast on but effort < 7 — must keep P3.
         use zencodec::{Cicp, Metadata};
         let pixels: Vec<Rgba<u8>> = (0..4)
-            .map(|i| Rgba { r: 100 + i, g: 100, b: 100, a: 255 })
+            .map(|i| Rgba {
+                r: 100 + i,
+                g: 100,
+                b: 100,
+                a: 255,
+            })
             .collect();
         let img = Img::new(pixels, 4, 1);
         let metadata = Metadata::none().with_cicp(Cicp::DISPLAY_P3);
@@ -1067,12 +1084,8 @@ mod tests {
             &Unstoppable,
         )
         .unwrap();
-        let decoded = crate::decode(
-            &encoded,
-            &crate::PngDecodeConfig::default(),
-            &Unstoppable,
-        )
-        .unwrap();
+        let decoded =
+            crate::decode(&encoded, &crate::PngDecodeConfig::default(), &Unstoppable).unwrap();
         assert_eq!(
             decoded.info.cicp,
             Some(Cicp::DISPLAY_P3),
@@ -1084,7 +1097,12 @@ mod tests {
     fn rgba8_with_default_flags_downcasts_to_gray() {
         // Same buffer, default flags — should auto-downcast to grayscale.
         let pixels: Vec<Rgba<u8>> = (0..4)
-            .map(|i| Rgba { r: i * 30, g: i * 30, b: i * 30, a: 255 })
+            .map(|i| Rgba {
+                r: i * 30,
+                g: i * 30,
+                b: i * 30,
+                a: 255,
+            })
             .collect();
         let img = Img::new(pixels, 4, 1);
         let config = EncodeConfig::default().with_compression(Compression::Fastest);

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -1015,7 +1015,7 @@ mod tests {
             .map(|i| Rgba {
                 r: 80 + (i * 3) as u8,
                 g: 90 + (i * 2) as u8,
-                b: 100 + (i * 1) as u8,
+                b: 100 + i as u8,
                 a: 255,
             })
             .collect();
@@ -1023,13 +1023,15 @@ mod tests {
 
         let metadata = Metadata::none().with_cicp(Cicp::DISPLAY_P3);
 
-        let mut flags = DowncastFlags::default();
-        flags.gamut_downcast = true;
         // Disable indexed/sub-byte to keep the test observation simple.
-        flags.indexed = false;
-        flags.sub_byte_gray = false;
-        flags.alpha_to_trns = false;
-        flags.rgb_to_gray = false;
+        let flags = DowncastFlags {
+            gamut_downcast: true,
+            indexed: false,
+            sub_byte_gray: false,
+            alpha_to_trns: false,
+            rgb_to_gray: false,
+            ..Default::default()
+        };
 
         let config = EncodeConfig::default()
             .with_compression(Compression::Fast) // effort 7
@@ -1067,12 +1069,14 @@ mod tests {
             .collect();
         let img = Img::new(pixels, 4, 1);
         let metadata = Metadata::none().with_cicp(Cicp::DISPLAY_P3);
-        let mut flags = DowncastFlags::default();
-        flags.gamut_downcast = true;
-        flags.indexed = false;
-        flags.sub_byte_gray = false;
-        flags.alpha_to_trns = false;
-        flags.rgb_to_gray = false;
+        let flags = DowncastFlags {
+            gamut_downcast: true,
+            indexed: false,
+            sub_byte_gray: false,
+            alpha_to_trns: false,
+            rgb_to_gray: false,
+            ..Default::default()
+        };
         let config = EncodeConfig::default()
             .with_compression(Compression::Turbo) // effort 2 < 7
             .with_downcast(flags);

--- a/src/gamut.rs
+++ b/src/gamut.rs
@@ -38,6 +38,7 @@ use zencodec::Cicp;
 /// 3×3 row-major matrix that converts linear-light Display P3 → linear
 /// BT.709 (sRGB primaries). White points are both D65 — no chromatic
 /// adaptation needed. Values match `zenpixels-convert::gamut`.
+#[allow(clippy::excessive_precision)]
 const DISPLAY_P3_TO_BT709: [[f32; 3]; 3] = [
     [1.2249401762, -0.2249398679, 0.0],
     [-0.0420569547, 1.0420571193, 0.0],
@@ -238,7 +239,7 @@ mod tests {
         // Should be very close to (128, 128, 128) in sRGB too, modulo
         // EOTF/OETF roundoff.
         for &b in &srgb {
-            assert!(b >= 127 && b <= 129, "gray drifted to {b}");
+            assert!((127..=129).contains(&b), "gray drifted to {b}");
         }
     }
 
@@ -302,13 +303,7 @@ mod tests {
         // Output should not be wildly different from input (pixel 0 is
         // mostly red — sRGB representation should still skew red).
         assert!(srgb[0] > srgb[1], "pixel 0 should still be R-dominant");
-        assert!(
-            srgb[3 + 1] > srgb[3 + 0],
-            "pixel 1 should still be G-dominant"
-        );
-        assert!(
-            srgb[6 + 2] > srgb[6 + 0],
-            "pixel 2 should still be B-dominant"
-        );
+        assert!(srgb[3 + 1] > srgb[3], "pixel 1 should still be G-dominant");
+        assert!(srgb[6 + 2] > srgb[6], "pixel 2 should still be B-dominant");
     }
 }

--- a/src/gamut.rs
+++ b/src/gamut.rs
@@ -302,7 +302,13 @@ mod tests {
         // Output should not be wildly different from input (pixel 0 is
         // mostly red — sRGB representation should still skew red).
         assert!(srgb[0] > srgb[1], "pixel 0 should still be R-dominant");
-        assert!(srgb[3 + 1] > srgb[3 + 0], "pixel 1 should still be G-dominant");
-        assert!(srgb[6 + 2] > srgb[6 + 0], "pixel 2 should still be B-dominant");
+        assert!(
+            srgb[3 + 1] > srgb[3 + 0],
+            "pixel 1 should still be G-dominant"
+        );
+        assert!(
+            srgb[6 + 2] > srgb[6 + 0],
+            "pixel 2 should still be B-dominant"
+        );
     }
 }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -1362,7 +1362,12 @@ mod tests {
     #[test]
     fn min_gray_bit_depth_2bit_values() {
         // Values that are multiples of 85 (0, 85, 170, 255) → 2-bit
-        let a = analyze_rgba8(&[85, 85, 85, 255, 170, 170, 170, 255], 2, 1, &DowncastFlags::default());
+        let a = analyze_rgba8(
+            &[85, 85, 85, 255, 170, 170, 170, 255],
+            2,
+            1,
+            &DowncastFlags::default(),
+        );
         assert!(a.is_grayscale);
         assert_eq!(a.min_gray_bit_depth, 2);
     }

--- a/src/simd/scan.rs
+++ b/src/simd/scan.rs
@@ -414,7 +414,11 @@ fn fused_predicates_rgba8_impl(token: Token, rgba: &[u8], req: FusedRequest) -> 
 // in the dead specialization, leaving a tighter hot loop.
 
 pub fn fused_predicates_rgba8_cg(rgba: &[u8], req: FusedRequest) -> FusedResult {
-    match (req.check_opaque, req.check_grayscale, req.check_binary_alpha) {
+    match (
+        req.check_opaque,
+        req.check_grayscale,
+        req.check_binary_alpha,
+    ) {
         (true, true, true) => fused_cg::<true, true, true>(rgba),
         (true, true, false) => fused_cg::<true, true, false>(rgba),
         (true, false, true) => fused_cg::<true, false, true>(rgba),
@@ -805,7 +809,9 @@ mod tests {
     #[test]
     fn grayscale_rgb8_true_three_pixels() {
         run_at_all_tiers("gray_rgb_true_3px", || {
-            assert!(super::is_grayscale_rgb8(&[10, 10, 10, 20, 20, 20, 30, 30, 30]));
+            assert!(super::is_grayscale_rgb8(&[
+                10, 10, 10, 20, 20, 20, 30, 30, 30
+            ]));
         });
     }
 
@@ -1128,16 +1134,10 @@ mod tests {
         }
     }
 
-
     fn rgba_pattern(n_pixels: usize, mutate: impl Fn(usize, &mut [u8; 4])) -> Vec<u8> {
         let mut v = Vec::with_capacity(n_pixels * 4);
         for i in 0..n_pixels {
-            let mut p = [
-                (i * 7 + 3) as u8,
-                (i * 7 + 3) as u8,
-                (i * 7 + 3) as u8,
-                255,
-            ];
+            let mut p = [(i * 7 + 3) as u8, (i * 7 + 3) as u8, (i * 7 + 3) as u8, 255];
             mutate(i, &mut p);
             v.extend_from_slice(&p);
         }
@@ -1149,17 +1149,29 @@ mod tests {
         let report = for_each_token_permutation(CompileTimePolicy::Warn, |_perm| {
             for &n in &[0usize, 1, 4, 15, 16, 17, 31, 64, 200, 1024, 4099] {
                 let v = rgba_pattern(n, |_, _| {});
-                assert_eq!(super::is_opaque_rgba8(&v), scalar_is_opaque(&v), "n={n} all-opaque");
+                assert_eq!(
+                    super::is_opaque_rgba8(&v),
+                    scalar_is_opaque(&v),
+                    "n={n} all-opaque"
+                );
                 if n > 5 {
                     let mut v = rgba_pattern(n, |_, _| {});
                     v[5 * 4 + 3] = 128;
-                    assert_eq!(super::is_opaque_rgba8(&v), scalar_is_opaque(&v), "n={n} pixel 5 alpha=128");
+                    assert_eq!(
+                        super::is_opaque_rgba8(&v),
+                        scalar_is_opaque(&v),
+                        "n={n} pixel 5 alpha=128"
+                    );
                 }
                 // Non-opaque at the very last pixel
                 if n > 0 {
                     let mut v = rgba_pattern(n, |_, _| {});
                     v[(n - 1) * 4 + 3] = 200;
-                    assert_eq!(super::is_opaque_rgba8(&v), scalar_is_opaque(&v), "n={n} last pixel alpha=200");
+                    assert_eq!(
+                        super::is_opaque_rgba8(&v),
+                        scalar_is_opaque(&v),
+                        "n={n} last pixel alpha=200"
+                    );
                 }
             }
         });
@@ -1171,19 +1183,31 @@ mod tests {
         let report = for_each_token_permutation(CompileTimePolicy::Warn, |_perm| {
             for &n in &[0usize, 1, 4, 16, 17, 64, 200, 4099] {
                 let v = rgba_pattern(n, |_, _| {});
-                assert_eq!(super::is_grayscale_rgba8(&v), scalar_is_grayscale_rgba8(&v), "n={n} all-gray");
+                assert_eq!(
+                    super::is_grayscale_rgba8(&v),
+                    scalar_is_grayscale_rgba8(&v),
+                    "n={n} all-gray"
+                );
                 if n > 5 {
                     let mut v = rgba_pattern(n, |_, _| {});
                     v[5 * 4] = 1;
                     v[5 * 4 + 1] = 2;
                     v[5 * 4 + 2] = 3;
-                    assert_eq!(super::is_grayscale_rgba8(&v), scalar_is_grayscale_rgba8(&v), "n={n} colorful pixel 5");
+                    assert_eq!(
+                        super::is_grayscale_rgba8(&v),
+                        scalar_is_grayscale_rgba8(&v),
+                        "n={n} colorful pixel 5"
+                    );
                 }
                 // Off-by-one: only G differs from R by 1
                 if n > 5 {
                     let mut v = rgba_pattern(n, |_, _| {});
                     v[5 * 4 + 1] = v[5 * 4].wrapping_add(1);
-                    assert_eq!(super::is_grayscale_rgba8(&v), scalar_is_grayscale_rgba8(&v), "n={n} g=r+1 at pixel 5");
+                    assert_eq!(
+                        super::is_grayscale_rgba8(&v),
+                        scalar_is_grayscale_rgba8(&v),
+                        "n={n} g=r+1 at pixel 5"
+                    );
                 }
             }
         });
@@ -1195,16 +1219,28 @@ mod tests {
         let report = for_each_token_permutation(CompileTimePolicy::Warn, |_perm| {
             for &n in &[0usize, 1, 4, 16, 64, 200, 4099] {
                 let v = rgba_pattern(n, |i, p| p[3] = if i & 1 == 0 { 0 } else { 255 });
-                assert_eq!(super::alpha_is_binary_rgba8(&v), scalar_alpha_binary(&v), "n={n} alternating 0/255");
+                assert_eq!(
+                    super::alpha_is_binary_rgba8(&v),
+                    scalar_alpha_binary(&v),
+                    "n={n} alternating 0/255"
+                );
                 if n > 5 {
                     let mut v = rgba_pattern(n, |i, p| p[3] = if i & 1 == 0 { 0 } else { 255 });
                     v[5 * 4 + 3] = 128;
-                    assert_eq!(super::alpha_is_binary_rgba8(&v), scalar_alpha_binary(&v), "n={n} alpha 128 at 5");
+                    assert_eq!(
+                        super::alpha_is_binary_rgba8(&v),
+                        scalar_alpha_binary(&v),
+                        "n={n} alpha 128 at 5"
+                    );
                 }
                 if n > 5 {
                     let mut v = rgba_pattern(n, |_, _| {});
                     v[5 * 4 + 3] = 1; // very small but nonzero
-                    assert_eq!(super::alpha_is_binary_rgba8(&v), scalar_alpha_binary(&v), "n={n} alpha 1 at 5");
+                    assert_eq!(
+                        super::alpha_is_binary_rgba8(&v),
+                        scalar_alpha_binary(&v),
+                        "n={n} alpha 1 at 5"
+                    );
                 }
             }
         });
@@ -1220,11 +1256,19 @@ mod tests {
                     let g = (i * 7 + 3) as u8;
                     v.extend_from_slice(&[g, g, g]);
                 }
-                assert_eq!(super::is_grayscale_rgb8(&v), scalar_is_grayscale_rgb8(&v), "n={n} all-gray");
+                assert_eq!(
+                    super::is_grayscale_rgb8(&v),
+                    scalar_is_grayscale_rgb8(&v),
+                    "n={n} all-gray"
+                );
                 if n > 80 {
                     let mut v2 = v.clone();
                     v2[80 * 3 + 1] = v2[80 * 3].wrapping_add(1);
-                    assert_eq!(super::is_grayscale_rgb8(&v2), scalar_is_grayscale_rgb8(&v2), "n={n} pixel 80 g+=1");
+                    assert_eq!(
+                        super::is_grayscale_rgb8(&v2),
+                        scalar_is_grayscale_rgb8(&v2),
+                        "n={n} pixel 80 g+=1"
+                    );
                 }
             }
         });

--- a/src/simd/scan.rs
+++ b/src/simd/scan.rs
@@ -13,6 +13,12 @@
 //! - RGB8:  `[R, G, B, R, G, B, …]` — 3 bytes/pixel
 //! - 16-bit: big-endian pairs `[hi, lo, hi, lo, …]`. Lossless 16→8 condition
 //!   is `hi == lo` (PNG bit-replication: `u16 = u8 * 0x0101`).
+//!
+//! Several predicates are scaffolding for upcoming encoder downcast
+//! optimizations and are not yet wired into the encode pipeline. Allow
+//! `dead_code` at module scope rather than scatter `#[allow]` per-item.
+
+#![allow(dead_code)]
 
 use archmage::prelude::*;
 


### PR DESCRIPTION
## Summary

Three HIGH findings from the 2026-05-06 security audit
(`/home/lilith/work/feedback/security-audit-2026-05-06/zenpng.md`). No
CRITICALs; `#![forbid(unsafe_code)]` plus existing IHDR / chunk-iter
defenses make the worst-case outcome here a panic / OOM, not memory
corruption.

### H1 — APNG cumulative frame memory exhaustion

`src/decoder/apng.rs` — `decode_apng_composed` pushed every
canvas-sized composited frame into `Vec<ApngFrame>` with no cumulative
budget. With 65536 `acTL.num_frames` and a 100 MP RGBA8 canvas, an
attacker file under a few KB could drive `frames` to ~25 TiB.
`PngDecodeConfig::max_memory_bytes` only governed the single canvas
allocation. Fix: track running per-frame byte sum, bail with
`PngError::LimitExceeded` once the configured `max_memory_bytes` is
exceeded — checked before allocating the next frame's pixel copy.

### H2 — Unbounded tEXt / zTXt / iTXt-XMP accumulation

`src/chunk/ancillary.rs` — `text_chunks` was unbounded; each zTXt and
compressed-iTXt chunk allocated a 1-4 MiB transient zlib output buffer
per chunk regardless of payload size, and the resulting `String` was
retained forever. Fix: introduce two per-file caps,
`MAX_TEXT_CHUNKS = 256` (drops further tEXt/zTXt entries while still
extracting `creating_tool` for `detect::probe` parity) and
`MAX_TEXT_COMPRESSED_BYTES = 4 MiB` (shared across zTXt and compressed
iTXt(XMP)), so further compressed payloads are skipped without
decompression once the budget is exhausted.

### H3 — Sub-byte unpack invariant undocumented

`src/decoder/postprocess.rs` — `unpack_sub_byte_gray` /
`unpack_sub_byte_indexed` indexed `raw[byte_idx]` directly under an
undocumented invariant (`raw.len() >= ceil(width × bit_depth / 8)`).
In-tree callers always satisfy this, but a future refactor that calls
`post_process_row` with a too-short row would panic. Fix: document the
invariant on `post_process_row` and the unpack helpers; swap unchecked
indexing for `slice::get` + `break` so a contract violation produces a
truncated row rather than a panic. Hot path is unchanged — `slice::get`
with a known-in-bounds index optimizes identically to `[idx]`.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets` — no new lints (`/tmp/clippy-zenpng.log`)
- [x] `cargo test --all-targets` — 654 passed, 0 failed, 8 ignored
- [x] `cargo test --doc` — 2 passed, 0 failed
- [ ] CI green on all platforms