### PR TITLE
docs(zenpng): document metadata encode arg (None drops ICC/EXIF) + error import path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ All notable changes to zenpng are documented here.
 
 ### Fixed
 
+- docs(readme): document the `metadata: Option<&Metadata>` encode argument
+  (the 2nd positional arg of `encode_rgba8`/`encode_rgb8`/…, 5th of
+  `encode_apng`). Every example passed `None`, which silently writes no
+  ICC/EXIF/XMP — contradicting the "full metadata roundtrip" headline.
+  Added inline `None`-drops-metadata comments, a decode→encode
+  metadata-preserving example, the `zencodec::Metadata` dependency, the
+  `zenpng::PngError` import path, and the `At<PngError>: std::error::Error`
+  (`?`-to-`main`) fact; fixed the non-compiling `At::location()` server
+  snippet to `e.frames().next()…`. Found by an insulated external-developer
+  usability test.
+
 - `cicp_pq_without_cms_is_an_encode_error` →
   `cicp_pq_without_cms_synthesizes_icc_from_bundle`: zenpixels-convert
   0.2.13 made CICP→ICC synthesis feature-independent (bundled blob), so

--- a/README.md
+++ b/README.md
@@ -28,10 +28,13 @@ let rgba = output.pixels.to_rgba8();                        // PixelBuffer<rgb::
 let rgba_bytes: Vec<u8> = rgba.copy_to_contiguous_bytes();  // width*height*4, packed R,G,B,A
 
 // --- Encode RGBA8 back to PNG ---
+// 2nd arg is `metadata: Option<&zencodec::Metadata>`: pass `Some(&meta)` to embed
+// ICC / EXIF / XMP / HDR chunks; `None` writes NO such metadata (see "Metadata" below).
 // The two trailing args are the cancellation token and the deadline; pass
 // `&Unstoppable` for both to opt out. `rgba.as_imgref()` reuses the buffer above;
 // to encode your OWN flat RGBA bytes, use `imgref::ImgRef::new(rgb::FromSlice::as_rgba(&bytes), w, h)`.
 let encoded = encode_rgba8(rgba.as_imgref(), None, &EncodeConfig::default(), &Unstoppable, &Unstoppable)?;
+//                                            ^^^^ None drops all ICC/EXIF/XMP — pass Some(&meta) to keep them.
 
 // Encode with a specific preset
 let config = EncodeConfig::default().with_compression(Compression::High);
@@ -47,20 +50,25 @@ zenpixels-convert = { version = "0.2", features = ["rgb", "imgref"] } # .to_rgba
 imgref = "1"   # ImgRef for encode input
 rgb = "0.8"    # rgb::Rgba<u8> + FromSlice::as_rgba
 enough = "0.4" # Unstoppable / cancellation tokens
+zencodec = "0.1" # zencodec::Metadata, for the `metadata` encode arg (see "Metadata")
 ```
 
 **Errors (for a server).** `decode`/`encode_*` return `Result<_, whereat::At<PngError>>`
-— the `At<…>` adds a build-time source location for logs. Unwrap it with
-`err.error()` (borrow) or `err.decompose().0` (owned), then match on the
-[`PngError`] enum (`LimitExceeded` → 413, `InvalidInput`/`Decode` → 400, etc.;
-it is `#[non_exhaustive]`, so keep a wildcard arm):
+where `PngError` is re-exported at the crate root (`use zenpng::PngError;`). The
+`At<…>` adds a build-time source location for logs. `At<PngError>` implements
+`std::error::Error`, so `?` bubbles it straight into a
+`fn main() -> Result<(), Box<dyn std::error::Error>>` or any `anyhow`/`eyre` chain
+— no manual conversion. To inspect it instead, unwrap with `err.error()` (borrow)
+or `err.decompose().0` (owned), then match on the `PngError` enum (`LimitExceeded`
+→ 413, `InvalidInput`/`Decode` → 400, etc.; it is `#[non_exhaustive]`, so keep a
+wildcard arm):
 
 ```rust
 match zenpng::decode(png_bytes, &PngDecodeConfig::default(), &enough::Unstoppable) {
     Ok(output) => { /* ... */ }
     Err(e) => {
-        // `e.location()` is the whereat capture site (file:line) — log it for triage.
-        if let Some(loc) = e.location() {
+        // The first trace frame is the whereat capture site (file:line) — log it for triage.
+        if let Some(loc) = e.frames().next().and_then(|f| f.location()) {
             eprintln!("decode failed at {}:{}", loc.file(), loc.line());
         }
         match e.error() {
@@ -151,6 +159,8 @@ let frames = vec![
 ];
 
 let config = ApngEncodeConfig::default();
+// 5th arg is `metadata: Option<&zencodec::Metadata>` — `None` drops all ICC/EXIF/XMP;
+// pass `Some(&meta)` to embed it (same as `encode_rgba8`, see "Metadata" below).
 let apng = encode_apng(&frames, width, height, &config, None, &Unstoppable, &Unstoppable)?;
 ```
 
@@ -237,8 +247,42 @@ interlaced and non-interlaced PNGs.
 
 ## Metadata
 
-ICC profiles, EXIF, and XMP are roundtripped through encode/decode. Color space
-chunks (gAMA, sRGB, cHRM, cICP) are preserved. Set them on `EncodeConfig`:
+ICC profiles, EXIF, and XMP roundtrip through encode/decode — **but only if you
+pass them.** They ride the `metadata: Option<&zencodec::Metadata>` argument (the
+2nd positional arg of `encode_rgba8` / `encode_rgb8` / … and the 5th of
+`encode_apng`). **`None` writes no ICC / EXIF / XMP at all** — there is no
+`EncodeConfig` setter for those three, so an `encode_*(…, None, …)` call silently
+drops them. To preserve metadata across a decode → encode roundtrip, build a
+`Metadata` from the decode `output.info` and pass `Some(&meta)`:
+
+```rust
+use zenpng::{EncodeConfig, PngDecodeConfig};
+use zencodec::Metadata;
+use enough::Unstoppable;
+use zenpixels_convert::PixelBufferConvertTypedExt; // .to_rgba8()
+
+let output = zenpng::decode(png_bytes, &PngDecodeConfig::default(), &Unstoppable)?;
+
+// Re-build a Metadata from the fields the decoder surfaced on `output.info`.
+// `with_icc`/`with_exif`/`with_xmp` accept `Vec<u8>`, `&[u8]`, or `Arc<[u8]>`.
+let mut meta = Metadata::none();
+if let Some(icc)  = output.info.icc_profile { meta = meta.with_icc(icc); }
+if let Some(exif) = output.info.exif        { meta = meta.with_exif(exif); }
+if let Some(xmp)  = output.info.xmp         { meta = meta.with_xmp(xmp); }
+if let Some(cicp) = output.info.cicp        { meta = meta.with_cicp(cicp); }
+
+let rgba = output.pixels.to_rgba8();
+let encoded = zenpng::encode_rgba8(
+    rgba.as_imgref(),
+    Some(&meta),                  // <-- carries ICC/EXIF/XMP through; `None` would drop them
+    &EncodeConfig::default(),
+    &Unstoppable,
+    &Unstoppable,
+)?;
+```
+
+The PNG color-space chunks gAMA, sRGB, and cHRM are set on `EncodeConfig` instead
+(they have no `Metadata` carrier):
 
 ```rust
 let config = EncodeConfig::default()
@@ -246,8 +290,9 @@ let config = EncodeConfig::default()
     .with_srgb_intent(Some(0));       // perceptual
 ```
 
-The decoder warns on conflicting color metadata (e.g., both sRGB and cICP present)
-via `PngWarning` variants.
+cICP and the HDR chunks (cLLI / mDCV) can be set on *either* side; when present on
+both, the `EncodeConfig` value wins. The decoder warns on conflicting color
+metadata (e.g., both sRGB and cICP present) via `PngWarning` variants.
 
 ## Feature flags
 


### PR DESCRIPTION
An "insulated external developer" usability test (an agent given only zenpng's README, no source) found a dangerous undocumented parameter and a couple of unstated facts. This fixes them.

## The foot-gun
Every README encode example passes `None` as the **2nd** positional arg of `encode_rgba8` (and 5th of `encode_apng`). That arg is `metadata: Option<&zencodec::Metadata>` (`src/encode.rs:377`, `:945`) — so `None` **silently writes no ICC / EXIF / XMP**, directly contradicting the README's "full metadata roundtrip" selling point. There is **no `EncodeConfig` setter** for those three (verified: `EncodeConfig` carries gAMA/sRGB/cHRM/cICP/HDR/pHYs/tEXt/tIME, but ICC/EXIF/XMP ride only the `metadata` arg — `encode_raw` at `src/encode.rs:534` builds them solely from `from_metadata`). The old "Metadata" section even told readers to "Set them on `EncodeConfig`", which is impossible for ICC/EXIF/XMP.

## Fixes
1. **Document `metadata: Option<&Metadata>`** at every `encode_rgba8`/`encode_apng` call site (inline `None`-drops-metadata comments) and rewrote the **Metadata** section with a concrete decode → encode roundtrip example: build a `zencodec::Metadata` from the decoder's `output.info` (`icc_profile`/`exif`/`xmp`/`cicp`) and pass `Some(&meta)`. Clarified the EncodeConfig-vs-Metadata split and the cICP/HDR override precedence (`EncodeConfig` wins).
2. **Named the `PngError` import path** (`use zenpng::PngError;` — re-exported at the crate root, `src/lib.rs:81`).
3. **Stated `At<PngError>: std::error::Error`** so `?` bubbles straight to `fn main() -> Result<(), Box<dyn std::error::Error>>` / anyhow / eyre with no manual conversion (`PngError` derives `thiserror::Error` at `src/error.rs:9`; `impl<E: core::error::Error> core::error::Error for At<E>` at `whereat/src/at.rs:1267`).
4. Added the `zencodec` dependency line (needed for `Metadata`; **not** re-exported from zenpng).
5. **Correctness fix** to the existing server snippet: `At<PngError>` has no `.location()` method (only `AtFrame` does), so the old `e.location()` did not compile — replaced with `e.frames().next().and_then(|f| f.location())`, matching whereat's own doc example.

README is markdown-only (not doctest-included); every snippet was verified against source. Found via an insulated external-developer test.