### PR TITLE
docs(zenpng): correct stale 100 MP → 120 MP default in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ use enough::Unstoppable;
 // Probe metadata without decoding pixels
 let info = probe(png_bytes)?;
 
-// Default: 100 MP limit, 4 GiB memory limit, checksums skipped
+// Default: 120 MP limit, 4 GiB memory limit, checksums skipped
 let output = decode(png_bytes, &PngDecodeConfig::default(), &Unstoppable)?;
 
 // No limits, no checksums


### PR DESCRIPTION
Doc-only fix for DOC/CODE drift.

`PngDecodeConfig::default()` uses `DEFAULT_MAX_PIXELS = 120_000_000` (`src/decode.rs:244`), but the README usage example comment said **100 MP limit**.

- `README.md` (~line 229): `// Default: 100 MP limit, ...` → `// Default: 120 MP limit, ...`

No code, no public API, no behavior change. CI verifies the build.