### PR TITLE
fix(error): stop resetting the At<PngError> trace in encode_apng

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1422,8 +1422,7 @@ impl PngAnimationFrameEncoder {
             self.metadata.as_ref(),
             cancel,
             &deadline,
-        )
-        .map_err(|e| e.decompose().0)?;
+        )?;
 
         Ok(EncodeOutput::new(data, ImageFormat::Png))
     }


### PR DESCRIPTION
## Problem

In the zencodec APNG `finish` path (`src/codec.rs`), the call was:

```rust
let data = crate::encode::encode_apng(.., cancel, &deadline)
    .map_err(|e| e.decompose().0)?;
```

`encode_apng` already returns `crate::error::Result<Vec<u8>>` = `Result<_, At<PngError>>`, and the enclosing `do_finish` also returns `Result<_, At<PngError>>`. So `.map_err(|e| e.decompose().0)` decomposed the `At<PngError>` down to the bare `PngError` (discarding the `AtTrace`), and the trailing `?` then re-wrapped it into a **fresh** `At<PngError>` capturing this line instead of the original error site — i.e. the trace was reset.

## Fix

Drop the `.map_err(...)` so plain `?` propagates the `At<PngError>` (and its original trace) unchanged. One line removed; no other change.

## Verification (all under `run-heavy`, no `target-cpu=native`)

- `cargo build -p zenpng` — ok (peak-RSS 0.39 GiB)
- `cargo test -p zenpng` — **667 passed / 0 failed / 14 ignored** (+ 3+1+2 in other test binaries), rc=0 (peak-RSS 11.13 GiB, 740s)
- `cargo clippy -p zenpng` — clean, rc=0
- `cargo fmt -p zenpng --check` — clean

Diff scope: `src/codec.rs` only (one line).