### PR TITLE
feat(error): split stringly errors into category-named variants + CategorizedError

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,11 +36,8 @@ jobs:
       - name: Test (default)
         run: cargo test
 
-      - name: Test (zencodec feature)
-        run: cargo test --features zencodec
-
-      - name: Test (zencodec + cms features)
-        run: cargo test --features zencodec,cms
+      - name: Test (cms feature)
+        run: cargo test --features cms
 
       - name: Test (zopfli feature)
         run: cargo test --features zopfli
@@ -121,11 +118,8 @@ jobs:
       - name: Test (no default features)
         run: cargo test --no-default-features
 
-      - name: Test (zencodec)
-        run: cargo test --no-default-features --features zencodec
-
-      - name: Test (quantize + zencodec)
-        run: cargo test --features "quantize,zencodec"
+      - name: Test (quantize)
+        run: cargo test --features quantize
 
       - name: Test (zopfli)
         run: cargo test --features zopfli
@@ -140,7 +134,7 @@ jobs:
         run: cargo test --features quantette
 
       - name: Test (all features except _dev)
-        run: cargo test --features "quantize,imagequant,quantette,joint,unchecked,zopfli,zencodec"
+        run: cargo test --features "quantize,imagequant,quantette,joint,unchecked,zopfli"
 
   clippy:
     name: Clippy
@@ -153,10 +147,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Clippy (all features)
-        run: cargo clippy --all-targets --features "quantize,imagequant,quantette,joint,unchecked,zopfli,zencodec" -- -D warnings
+        run: cargo clippy --all-targets --features "quantize,imagequant,quantette,joint,unchecked,zopfli" -- -D warnings
 
-      - name: Clippy (zencodec only)
-        run: cargo clippy --all-targets --no-default-features --features zencodec -- -D warnings
+      - name: Clippy (no default features)
+        run: cargo clippy --all-targets --no-default-features -- -D warnings
 
   fmt:
     name: Format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to zenpng are documented here.
 ## [Unreleased]
 
 ### Added
+- **Codec-agnostic error taxonomy (`zencodec::CategorizedError`).** `PngError`
+  and the caller-facing `detect::ProbeError` now implement
+  `zencodec::CategorizedError` (`codec_name() = Some("zenpng")` + total `category()`), so
+  a consumer can route on the coarse `ErrorCategory` (HTTP status, retry policy,
+  logging) without matching the enum. The stringly variants were split into
+  discrete, category-named ones: new `Truncated` (→ `UnexpectedEof`),
+  `UnsupportedFeature` (→ `UnsupportedImageFeature`), `Unsupported(UnsupportedOperation)`
+  (delegates — `PixelFormat` → `UnsupportedPixelFormat`), `Io` (→ `Io`), and
+  `Limit(zencodec::LimitExceeded)` (delegates, **carries the `LimitKind`**). The
+  16 truncation/EOF decode sites, the 3 output-sink sites, and every configured-
+  limit site (encoder `check_*`, decoder pixel/memory caps, APNG cumulative-
+  memory + `acTL` frame cap, the >u32 IDAT guard) were rewired to construct the
+  precise variant. The kept variants narrowed in meaning: `Decode` →
+  `MalformedImage`, `InvalidInput` → `InvalidParameters`, `LimitExceeded` →
+  `OutOfMemory` (now only allocation-failure / address-space-overflow sites).
+  `Quantize` maps to `Internal` (delegating would need zenquant to impl
+  `CategorizedError` — a follow-up). All additive on `#[non_exhaustive]`; no
+  public variant removed or renamed.
 - **Palette/quantize axis on the sweep plan (`sweep::QuantizeSpec` +
   `QuantBackend`).** `SweepVariant` gains an optional `quantize` stratum:
   `None` = truecolor lossless (unchanged), `Some(spec)` = palette-reduce to
@@ -26,8 +44,47 @@ All notable changes to zenpng are documented here.
   `heuristics` resource-estimation, `detect` source-analysis, `cms`/`unchecked`,
   and native `zencodec` Fidelity APIs; added `benchmarks/README.md` and the
   canonical crosslink footer.
+- **The `zencodec` trait impls now return the `At<zencodec::CodecError>`
+  envelope (Pattern B), not `At<PngError>`.** Every encode/decode trait impl —
+  `PngEncoderConfig` / `PngEncodeJob` / `PngEncoder` / `PngAnimationFrameEncoder`
+  and `PngDecoderConfig` / `PngDecodeJob` / `PngDecoder` / `PngStreamingDecoder`
+  / `PngAnimationFrameDecoder` — sets `type Error = At<CodecError>` and wraps its
+  native error in the shared envelope (`CodecError::of` for already-located
+  errors, the new `From<PngError> for At<CodecError>` bridge for bare ones). A
+  generic consumer can now recover the `ErrorCategory` **and** the codec name
+  (`"zenpng"`) *through `Dyn*` dispatch*: once the error is erased to
+  `Box<dyn Error>`, the envelope downcasts back, where the previous
+  `At<PngError>` left no shared concrete type to recover (both were lost). The
+  internal logic is unchanged — each trait method delegates to a private
+  `At<PngError>` body and converts once at the boundary. `PngError` (and
+  `detect::ProbeError`) are untouched and remain the typed **detail** + category
+  source inside the envelope. The codec's inherent rich-error API — the free
+  `zenpng::decode` / `encode_*` functions and the `PngDecoderConfig::decode` /
+  `probe` / `decode_into_*` + `PngEncoderConfig::encode_*` convenience methods —
+  still returns `At<PngError>`, so direct PNG callers keep ergonomic enum
+  matching. Regression gate: `codec::tests::envelope_category_survives_dyn_erasure`
+  drives the decoder through `DynDecoderConfig` and asserts category + codec name
+  survive `Box<dyn Error>` erasure.
+- **`zencodec` is now a required (non-optional) dependency; the empty `zencodec`
+  marker cargo feature is removed.** The trait integration
+  (`PngEncoderConfig: EncoderConfig`, `PngDecoderConfig: DecoderConfig`, the
+  `CategorizedError` impls on `PngError` / `ProbeError`, and the
+  color-emit / orientation / metadata flow) was already compiled
+  unconditionally — the `zencodec = []` feature gated nothing — so this drop
+  only removes the no-op flag and the redundant `--features zencodec` /
+  `zencodec`-only CI steps. The integration adds no `std`-only code (`zencodec`
+  is `#![no_std] + alloc`), so the `wasm32-wasip1`, `wasm32-unknown-unknown`,
+  and `--no-default-features` builds are unaffected.
 
 ### Fixed
+- **`sweep_cells_decode_exactly_and_steps_are_live` no longer panics on feature
+  subsets.** The plan always carries every quantize cell (per
+  `modes_full_has_all_eight_quantize_cells`), but a cell can only be *encoded*
+  when its backend feature is compiled in; the test now filters cells to the
+  available backends (gated by `cfg!(feature = ...)`, controlled by the CI
+  feature matrix) instead of `.unwrap()`-ing the clean "needs the `imagequant`
+  feature" error. Fixes the pre-existing red `cargo test` (default / no-default /
+  `zencodec`-only) jobs on `main`.
 - **encode peak-memory estimate is now admission-gating-safe (never under-
   predicts).** Admission control gates on `EncodeEstimate::peak_memory_bytes`
   (the `typ` field), so it must be a safe upper bound. A VmHWM re-sweep

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ quantette = ["dep:quantette"]
 joint = ["quantize", "zenquant/joint"]
 unchecked = ["zenflate/unchecked"]
 zopfli = ["dep:zenzop"]
-zencodec = []
 # ICC synthesis for the zencodec color-emit path, via zenpixels-convert's
 # `icc-db` feature: a bundled LZ4 profile blob + pure-Rust lz4_flex decoder —
 # no moxcms. Covers the full ITU-T H.273 grid incl PQ/HLG (without it, only
@@ -119,3 +118,9 @@ required-features = ["_dev"]
 name = "scalar_vs_simd"
 harness = false
 required-features = ["_dev"]
+
+[patch.crates-io]
+# TEMP: until zencodec 0.1.26 ships (PR #103) — provides the unreleased
+# `CategorizedError` taxonomy (trait + `ErrorCategory` + `LimitKind`). Remove
+# this patch and bump the `zencodec` version dependency once 0.1.26 is published.
+zencodec = { git = "https://github.com/imazen/zencodec", branch = "cancellation-classification-99" }

--- a/src/chunk/ancillary.rs
+++ b/src/chunk/ancillary.rs
@@ -241,10 +241,10 @@ impl PngAncillary {
                     return Err(at!(PngError::Decode("acTL: num_frames must be > 0".into())));
                 }
                 if num_frames > 65536 {
-                    return Err(at!(PngError::LimitExceeded(alloc::format!(
-                        "acTL: num_frames {} exceeds limit of 65536",
-                        num_frames
-                    ))));
+                    return Err(at!(PngError::Limit(zencodec::LimitExceeded::Frames {
+                        actual: num_frames,
+                        max: 65536,
+                    })));
                 }
                 self.actl = Some((num_frames, num_plays));
             }

--- a/src/chunk/mod.rs
+++ b/src/chunk/mod.rs
@@ -70,7 +70,7 @@ impl<'a> Iterator for ChunkIter<'a> {
 
             // Need at least 12 bytes: length(4) + type(4) + crc(4) (data can be 0)
             if self.pos + 12 > self.data.len() {
-                return Some(Err(PngError::Decode("truncated chunk header".into())));
+                return Some(Err(PngError::Truncated("truncated chunk header".into())));
             }
 
             let length =

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -12,7 +12,7 @@ use alloc::vec::Vec;
 use whereat::{At, at};
 use zencodec::decode::{AnimationFrame, DecodeCapabilities, DecodeOutput, OutputInfo};
 use zencodec::encode::{EncodeCapabilities, EncodeOutput};
-use zencodec::{ImageFormat, ImageInfo, Metadata, ResourceLimits};
+use zencodec::{CodecError, ImageFormat, ImageInfo, Metadata, ResourceLimits};
 use zenpixels::{Pixel, PixelDescriptor, PixelSlice, PixelSliceMut};
 
 use crate::decode::PngDecodeConfig;
@@ -152,11 +152,11 @@ impl PngEncoderConfig {
         &self,
         img: imgref::ImgRef<'_, Rgb<u8>>,
     ) -> Result<EncodeOutput, At<PngError>> {
-        use zencodec::encode::{EncodeJob, Encoder, EncoderConfig};
+        use zencodec::encode::EncoderConfig;
         self.clone()
             .job()
-            .encoder()?
-            .encode(PixelSlice::from(img).erase())
+            .into_png_encoder()
+            .encode_inner(PixelSlice::from(img).erase())
     }
 
     /// Convenience: encode RGBA8 pixels in one call.
@@ -164,11 +164,11 @@ impl PngEncoderConfig {
         &self,
         img: imgref::ImgRef<'_, Rgba<u8>>,
     ) -> Result<EncodeOutput, At<PngError>> {
-        use zencodec::encode::{EncodeJob, Encoder, EncoderConfig};
+        use zencodec::encode::EncoderConfig;
         self.clone()
             .job()
-            .encoder()?
-            .encode(PixelSlice::from(img).erase())
+            .into_png_encoder()
+            .encode_inner(PixelSlice::from(img).erase())
     }
 
     /// Convenience: encode Gray8 pixels in one call.
@@ -176,11 +176,11 @@ impl PngEncoderConfig {
         &self,
         img: imgref::ImgRef<'_, Gray<u8>>,
     ) -> Result<EncodeOutput, At<PngError>> {
-        use zencodec::encode::{EncodeJob, Encoder, EncoderConfig};
+        use zencodec::encode::EncoderConfig;
         self.clone()
             .job()
-            .encoder()?
-            .encode(PixelSlice::from(img).erase())
+            .into_png_encoder()
+            .encode_inner(PixelSlice::from(img).erase())
     }
 
     /// Convenience: encode RGB16 pixels in one call.
@@ -188,11 +188,11 @@ impl PngEncoderConfig {
         &self,
         img: imgref::ImgRef<'_, Rgb<u16>>,
     ) -> Result<EncodeOutput, At<PngError>> {
-        use zencodec::encode::{EncodeJob, Encoder, EncoderConfig};
+        use zencodec::encode::EncoderConfig;
         self.clone()
             .job()
-            .encoder()?
-            .encode(PixelSlice::from(img).erase())
+            .into_png_encoder()
+            .encode_inner(PixelSlice::from(img).erase())
     }
 
     /// Convenience: encode RGBA16 pixels in one call.
@@ -200,11 +200,11 @@ impl PngEncoderConfig {
         &self,
         img: imgref::ImgRef<'_, Rgba<u16>>,
     ) -> Result<EncodeOutput, At<PngError>> {
-        use zencodec::encode::{EncodeJob, Encoder, EncoderConfig};
+        use zencodec::encode::EncoderConfig;
         self.clone()
             .job()
-            .encoder()?
-            .encode(PixelSlice::from(img).erase())
+            .into_png_encoder()
+            .encode_inner(PixelSlice::from(img).erase())
     }
 
     /// Convenience: encode Gray16 pixels in one call.
@@ -212,11 +212,11 @@ impl PngEncoderConfig {
         &self,
         img: imgref::ImgRef<'_, Gray<u16>>,
     ) -> Result<EncodeOutput, At<PngError>> {
-        use zencodec::encode::{EncodeJob, Encoder, EncoderConfig};
+        use zencodec::encode::EncoderConfig;
         self.clone()
             .job()
-            .encoder()?
-            .encode(PixelSlice::from(img).erase())
+            .into_png_encoder()
+            .encode_inner(PixelSlice::from(img).erase())
     }
 
     /// Convenience: encode RGB F32 pixels in one call.
@@ -224,11 +224,11 @@ impl PngEncoderConfig {
         &self,
         img: imgref::ImgRef<'_, Rgb<f32>>,
     ) -> Result<EncodeOutput, At<PngError>> {
-        use zencodec::encode::{EncodeJob, Encoder, EncoderConfig};
+        use zencodec::encode::EncoderConfig;
         self.clone()
             .job()
-            .encoder()?
-            .encode(PixelSlice::from(img).erase())
+            .into_png_encoder()
+            .encode_inner(PixelSlice::from(img).erase())
     }
 
     /// Convenience: encode RGBA F32 pixels in one call.
@@ -236,11 +236,11 @@ impl PngEncoderConfig {
         &self,
         img: imgref::ImgRef<'_, Rgba<f32>>,
     ) -> Result<EncodeOutput, At<PngError>> {
-        use zencodec::encode::{EncodeJob, Encoder, EncoderConfig};
+        use zencodec::encode::EncoderConfig;
         self.clone()
             .job()
-            .encoder()?
-            .encode(PixelSlice::from(img).erase())
+            .into_png_encoder()
+            .encode_inner(PixelSlice::from(img).erase())
     }
 
     /// Convenience: encode Gray F32 pixels in one call.
@@ -248,11 +248,11 @@ impl PngEncoderConfig {
         &self,
         img: imgref::ImgRef<'_, Gray<f32>>,
     ) -> Result<EncodeOutput, At<PngError>> {
-        use zencodec::encode::{EncodeJob, Encoder, EncoderConfig};
+        use zencodec::encode::EncoderConfig;
         self.clone()
             .job()
-            .encoder()?
-            .encode(PixelSlice::from(img).erase())
+            .into_png_encoder()
+            .encode_inner(PixelSlice::from(img).erase())
     }
 
     /// Convenience: encode BGRA8 pixels (swizzles to RGBA) in one call.
@@ -260,11 +260,11 @@ impl PngEncoderConfig {
         &self,
         img: imgref::ImgRef<'_, rgb::alt::BGRA<u8>>,
     ) -> Result<EncodeOutput, At<PngError>> {
-        use zencodec::encode::{EncodeJob, Encoder, EncoderConfig};
+        use zencodec::encode::EncoderConfig;
         self.clone()
             .job()
-            .encoder()?
-            .encode(PixelSlice::from(img).erase())
+            .into_png_encoder()
+            .encode_inner(PixelSlice::from(img).erase())
     }
 }
 
@@ -448,7 +448,7 @@ static PNG_ENCODE_CAPS: EncodeCapabilities = EncodeCapabilities::new()
     .with_threads_supported_range(1, 16);
 
 impl zencodec::encode::EncoderConfig for PngEncoderConfig {
-    type Error = At<PngError>;
+    type Error = At<CodecError>;
     type Job = PngEncodeJob;
 
     fn format() -> ImageFormat {
@@ -581,7 +581,7 @@ pub struct PngEncodeJob {
 }
 
 impl zencodec::encode::EncodeJob for PngEncodeJob {
-    type Error = At<PngError>;
+    type Error = At<CodecError>;
     type Enc = PngEncoder;
     type AnimationFrameEnc = PngAnimationFrameEncoder;
 
@@ -616,25 +616,17 @@ impl zencodec::encode::EncodeJob for PngEncodeJob {
         self
     }
 
-    fn encoder(self) -> Result<PngEncoder, At<PngError>> {
-        Ok(PngEncoder {
-            config: self.config,
-            stop: self.stop,
-            metadata: self.metadata,
-            limits: self.limits,
-            policy: self.policy,
-            canvas_width: self.canvas_width,
-            canvas_height: self.canvas_height,
-            streaming: None,
-        })
+    fn encoder(self) -> Result<PngEncoder, At<CodecError>> {
+        Ok(self.into_png_encoder())
     }
 
-    fn animation_frame_encoder(self) -> Result<PngAnimationFrameEncoder, At<PngError>> {
+    fn animation_frame_encoder(self) -> Result<PngAnimationFrameEncoder, At<CodecError>> {
         // Frame pixel format isn't known until frames are pushed; the color-emit
         // resolver still classifies gray/CMYK from the ICC color space, and
         // APNG frames are RGB/RGBA, so a `None` channel count is correct here.
         let effective_meta =
-            apply_encode_policy(self.metadata.as_ref(), self.policy.as_ref(), None)?;
+            apply_encode_policy(self.metadata.as_ref(), self.policy.as_ref(), None)
+                .map_err(CodecError::of)?;
         let mut config = self.config.config.clone();
         if let Some(ref limits) = self.limits {
             apply_threading(&mut config, limits.threading());
@@ -648,6 +640,25 @@ impl zencodec::encode::EncodeJob for PngEncodeJob {
         enc.loop_count = self.loop_count.unwrap_or(0);
         enc.limits = self.limits;
         Ok(enc)
+    }
+}
+
+impl PngEncodeJob {
+    /// Build the concrete [`PngEncoder`] (infallible). Shared by the
+    /// [`EncodeJob::encoder`](zencodec::encode::EncodeJob::encoder) trait method
+    /// (which returns the `At<CodecError>` envelope) and the codec's inherent
+    /// `encode_*` convenience API (which returns the rich `At<PngError>`).
+    fn into_png_encoder(self) -> PngEncoder {
+        PngEncoder {
+            config: self.config,
+            stop: self.stop,
+            metadata: self.metadata,
+            limits: self.limits,
+            policy: self.policy,
+            canvas_width: self.canvas_width,
+            canvas_height: self.canvas_height,
+            streaming: None,
+        }
     }
 }
 
@@ -787,7 +798,7 @@ impl PngEncoder {
         if let Some(ref limits) = self.limits {
             limits
                 .check_dimensions(w, h)
-                .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+                .map_err(|e| at!(PngError::Limit(e)))?;
             let channels: u64 = match color_type {
                 crate::encode::ColorType::Grayscale => 1,
                 crate::encode::ColorType::Rgb => 3,
@@ -802,7 +813,7 @@ impl PngEncoder {
             let estimated_mem = w as u64 * h as u64 * bpp;
             limits
                 .check_memory(estimated_mem)
-                .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+                .map_err(|e| at!(PngError::Limit(e)))?;
         }
         let config = self.config_with_threading();
         let deadline = default_deadline();
@@ -820,24 +831,38 @@ impl PngEncoder {
         if let Some(ref limits) = self.limits {
             limits
                 .check_output_size(data.len() as u64)
-                .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+                .map_err(|e| at!(PngError::Limit(e)))?;
         }
         Ok(EncodeOutput::new(data, ImageFormat::Png))
     }
 }
 
 impl zencodec::encode::Encoder for PngEncoder {
-    type Error = At<PngError>;
+    type Error = At<CodecError>;
 
-    fn reject(op: zencodec::UnsupportedOperation) -> At<PngError> {
-        at!(PngError::from(op))
+    fn reject(op: zencodec::UnsupportedOperation) -> At<CodecError> {
+        PngError::from(op).into()
     }
 
     fn preferred_strip_height(&self) -> u32 {
         1 // PNG uses row-at-a-time filtering
     }
 
-    fn encode(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, At<PngError>> {
+    fn encode(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, At<CodecError>> {
+        self.encode_inner(pixels).map_err(CodecError::of)
+    }
+
+    fn push_rows(&mut self, rows: PixelSlice<'_>) -> Result<(), At<CodecError>> {
+        self.push_rows_inner(rows).map_err(CodecError::of)
+    }
+
+    fn finish(self) -> Result<EncodeOutput, At<CodecError>> {
+        self.finish_inner().map_err(CodecError::of)
+    }
+}
+
+impl PngEncoder {
+    fn encode_inner(self, pixels: PixelSlice<'_>) -> Result<EncodeOutput, At<PngError>> {
         use linear_srgb::default::{linear_to_srgb_u8_rgba_slice, linear_to_srgb_u8_slice};
         use zenpixels::PixelFormat;
 
@@ -1010,7 +1035,7 @@ impl zencodec::encode::Encoder for PngEncoder {
         }
     }
 
-    fn push_rows(&mut self, rows: PixelSlice<'_>) -> Result<(), At<PngError>> {
+    fn push_rows_inner(&mut self, rows: PixelSlice<'_>) -> Result<(), At<PngError>> {
         use linear_srgb::default::{linear_to_srgb_u8_rgba_slice, linear_to_srgb_u8_slice};
         use zenpixels::PixelFormat;
 
@@ -1314,7 +1339,7 @@ impl zencodec::encode::Encoder for PngEncoder {
         Ok(())
     }
 
-    fn finish(mut self) -> Result<EncodeOutput, At<PngError>> {
+    fn finish_inner(mut self) -> Result<EncodeOutput, At<PngError>> {
         let mode = self.streaming.take().ok_or_else(|| {
             at!(PngError::InvalidInput(
                 "finish() called without any push_rows() calls".into()
@@ -1358,7 +1383,7 @@ impl zencodec::encode::Encoder for PngEncoder {
                 if let Some(ref limits) = self.limits {
                     limits
                         .check_output_size(data.len() as u64)
-                        .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+                        .map_err(|e| at!(PngError::Limit(e)))?;
                 }
                 Ok(EncodeOutput::new(data, ImageFormat::Png))
             }
@@ -1374,7 +1399,7 @@ impl zencodec::encode::Encoder for PngEncoder {
                 if let Some(ref limits) = self.limits {
                     limits
                         .check_output_size(data.len() as u64)
-                        .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+                        .map_err(|e| at!(PngError::Limit(e)))?;
                 }
                 Ok(EncodeOutput::new(data, ImageFormat::Png))
             }
@@ -1474,10 +1499,10 @@ impl PngAnimationFrameEncoder {
 }
 
 impl zencodec::encode::AnimationFrameEncoder for PngAnimationFrameEncoder {
-    type Error = At<PngError>;
+    type Error = At<CodecError>;
 
-    fn reject(op: zencodec::UnsupportedOperation) -> At<PngError> {
-        at!(PngError::from(op))
+    fn reject(op: zencodec::UnsupportedOperation) -> At<CodecError> {
+        PngError::from(op).into()
     }
 
     fn push_frame(
@@ -1485,19 +1510,19 @@ impl zencodec::encode::AnimationFrameEncoder for PngAnimationFrameEncoder {
         pixels: PixelSlice<'_>,
         duration_ms: u32,
         _stop: Option<&dyn enough::Stop>,
-    ) -> Result<(), At<PngError>> {
-        let rgba = Self::pixels_to_rgba8(&pixels)?;
+    ) -> Result<(), At<CodecError>> {
+        let rgba = Self::pixels_to_rgba8(&pixels).map_err(CodecError::of)?;
         // Check resource limits before accumulating
         if let Some(ref limits) = self.limits {
             // Check max_frames (new frame count = current + 1)
             limits
                 .check_frames(self.frames.len() as u32 + 1)
-                .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+                .map_err(|e| CodecError::of(at!(PngError::Limit(e))))?;
             // Check max_memory (cumulative pixel data size)
             let new_cumulative = self.cumulative_pixel_bytes + rgba.len() as u64;
             limits
                 .check_memory(new_cumulative)
-                .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+                .map_err(|e| CodecError::of(at!(PngError::Limit(e))))?;
         }
         self.cumulative_pixel_bytes += rgba.len() as u64;
         self.frames.push(AccumulatedFrame {
@@ -1507,8 +1532,8 @@ impl zencodec::encode::AnimationFrameEncoder for PngAnimationFrameEncoder {
         Ok(())
     }
 
-    fn finish(self, stop: Option<&dyn enough::Stop>) -> Result<EncodeOutput, At<PngError>> {
-        self.do_finish(stop)
+    fn finish(self, stop: Option<&dyn enough::Stop>) -> Result<EncodeOutput, At<CodecError>> {
+        self.do_finish(stop).map_err(CodecError::of)
     }
 }
 
@@ -1597,17 +1622,17 @@ impl PngDecoderConfig {
 
     /// Convenience: decode in one call (native format).
     pub fn decode(&self, data: &[u8]) -> Result<DecodeOutput, At<PngError>> {
-        use zencodec::decode::{Decode, DecodeJob, DecoderConfig};
+        use zencodec::decode::DecoderConfig;
         self.clone()
             .job()
-            .decoder(Cow::Borrowed(data), &[])?
-            .decode()
+            .into_png_decoder(Cow::Borrowed(data), &[])
+            .decode_inner()
     }
 
     /// Convenience: probe image header.
     pub fn probe(&self, data: &[u8]) -> Result<ImageInfo, At<PngError>> {
-        use zencodec::decode::{DecodeJob, DecoderConfig};
-        self.clone().job().probe(data)
+        use zencodec::decode::DecoderConfig;
+        self.clone().job().probe_inner(data)
     }
 
     /// Convenience: probe header (alias for backwards compatibility).
@@ -1711,7 +1736,7 @@ static PNG_DECODE_CAPS: DecodeCapabilities = DecodeCapabilities::new()
     .with_enforces_max_input_bytes(true);
 
 impl zencodec::decode::DecoderConfig for PngDecoderConfig {
-    type Error = At<PngError>;
+    type Error = At<CodecError>;
     type Job<'a> = PngDecodeJob;
 
     fn formats() -> &'static [ImageFormat] {
@@ -1769,7 +1794,7 @@ pub struct PngDecodeJob {
 }
 
 impl<'a> zencodec::decode::DecodeJob<'a> for PngDecodeJob {
-    type Error = At<PngError>;
+    type Error = At<CodecError>;
     type Dec = PngDecoder<'a>;
     type StreamDec = PngStreamingDecoder<'a>;
     type AnimationFrameDec = PngAnimationFrameDecoder;
@@ -1794,18 +1819,12 @@ impl<'a> zencodec::decode::DecodeJob<'a> for PngDecodeJob {
         self
     }
 
-    fn probe(&self, data: &[u8]) -> Result<ImageInfo, At<PngError>> {
-        let info = crate::decode::probe(data)?;
-        let mut image_info = convert_info(&info);
-        if let Ok(probe) = crate::detect::probe(data) {
-            image_info = image_info.with_source_encoding_details(probe);
-        }
-        apply_policy_to_info(&mut image_info, self.policy.as_ref());
-        Ok(image_info)
+    fn probe(&self, data: &[u8]) -> Result<ImageInfo, At<CodecError>> {
+        self.probe_inner(data).map_err(CodecError::of)
     }
 
-    fn output_info(&self, data: &[u8]) -> Result<OutputInfo, At<PngError>> {
-        let info = crate::decode::probe(data)?;
+    fn output_info(&self, data: &[u8]) -> Result<OutputInfo, At<CodecError>> {
+        let info = crate::decode::probe(data).map_err(CodecError::of)?;
         // Derive has_trns: has_alpha is set for color types 4/6 (intrinsic alpha)
         // or when a tRNS chunk is present. If has_alpha is true but color_type
         // doesn't have intrinsic alpha, then tRNS must be present.
@@ -1825,22 +1844,15 @@ impl<'a> zencodec::decode::DecodeJob<'a> for PngDecodeJob {
         self,
         data: Cow<'a, [u8]>,
         preferred: &[PixelDescriptor],
-    ) -> Result<PngDecoder<'a>, At<PngError>> {
-        Ok(PngDecoder {
-            config: self.config,
-            stop: self.stop,
-            limits: self.limits,
-            policy: self.policy,
-            data,
-            preferred: preferred.to_vec(),
-        })
+    ) -> Result<PngDecoder<'a>, At<CodecError>> {
+        Ok(self.into_png_decoder(data, preferred))
     }
 
     fn streaming_decoder(
         self,
         data: Cow<'a, [u8]>,
         preferred: &[PixelDescriptor],
-    ) -> Result<PngStreamingDecoder<'a>, At<PngError>> {
+    ) -> Result<PngStreamingDecoder<'a>, At<CodecError>> {
         PngStreamingDecoder::new(
             data,
             &self.config,
@@ -1849,26 +1861,27 @@ impl<'a> zencodec::decode::DecodeJob<'a> for PngDecodeJob {
             self.policy.as_ref(),
             preferred,
         )
+        .map_err(CodecError::of)
     }
 
     fn animation_frame_decoder(
         self,
         data: Cow<'a, [u8]>,
         preferred: &[PixelDescriptor],
-    ) -> Result<PngAnimationFrameDecoder, At<PngError>> {
+    ) -> Result<PngAnimationFrameDecoder, At<CodecError>> {
         // Reject animation when policy forbids it
         if let Some(ref policy) = self.policy
             && !policy.resolve_animation(true)
         {
-            return Err(at!(PngError::InvalidInput(
-                "animation rejected by decode policy".into()
-            )));
+            return Err(
+                PngError::InvalidInput("animation rejected by decode policy".into()).into(),
+            );
         }
         // Check input size limit
         let effective_limits = self.limits.as_ref().unwrap_or(&self.config.limits);
         effective_limits
             .check_input_size(data.len() as u64)
-            .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+            .map_err(|e| CodecError::of(at!(PngError::Limit(e))))?;
         PngAnimationFrameDecoder::new(
             &data,
             &self.config,
@@ -1877,6 +1890,7 @@ impl<'a> zencodec::decode::DecodeJob<'a> for PngDecodeJob {
             preferred,
             self.start_frame_index,
         )
+        .map_err(CodecError::of)
     }
 
     fn push_decoder(
@@ -1884,8 +1898,43 @@ impl<'a> zencodec::decode::DecodeJob<'a> for PngDecodeJob {
         data: Cow<'a, [u8]>,
         sink: &mut dyn zencodec::decode::DecodeRowSink,
         preferred: &[PixelDescriptor],
-    ) -> Result<OutputInfo, At<PngError>> {
+    ) -> Result<OutputInfo, At<CodecError>> {
         push_decoder_native(self, data, sink, preferred)
+    }
+}
+
+impl PngDecodeJob {
+    /// Build the concrete [`PngDecoder`] (infallible). Shared by the
+    /// [`DecodeJob::decoder`](zencodec::decode::DecodeJob::decoder) trait method
+    /// (which returns the `At<CodecError>` envelope) and the codec's inherent
+    /// `decode`/`decode_into_*` convenience API (which returns the rich
+    /// `At<PngError>`).
+    fn into_png_decoder<'a>(
+        self,
+        data: Cow<'a, [u8]>,
+        preferred: &[PixelDescriptor],
+    ) -> PngDecoder<'a> {
+        PngDecoder {
+            config: self.config,
+            stop: self.stop,
+            limits: self.limits,
+            policy: self.policy,
+            data,
+            preferred: preferred.to_vec(),
+        }
+    }
+
+    /// Probe the header, returning the rich `At<PngError>`. Backs both the
+    /// `DecodeJob::probe` trait method (wrapped into the envelope) and the
+    /// inherent `PngDecoderConfig::probe` convenience method.
+    fn probe_inner(&self, data: &[u8]) -> Result<ImageInfo, At<PngError>> {
+        let info = crate::decode::probe(data)?;
+        let mut image_info = convert_info(&info);
+        if let Ok(probe) = crate::detect::probe(data) {
+            image_info = image_info.with_source_encoding_details(probe);
+        }
+        apply_policy_to_info(&mut image_info, self.policy.as_ref());
+        Ok(image_info)
     }
 }
 
@@ -1916,9 +1965,15 @@ impl PngDecoder<'_> {
 }
 
 impl zencodec::decode::Decode for PngDecoder<'_> {
-    type Error = At<PngError>;
+    type Error = At<CodecError>;
 
-    fn decode(self) -> Result<DecodeOutput, At<PngError>> {
+    fn decode(self) -> Result<DecodeOutput, At<CodecError>> {
+        self.decode_inner().map_err(CodecError::of)
+    }
+}
+
+impl PngDecoder<'_> {
+    fn decode_inner(self) -> Result<DecodeOutput, At<PngError>> {
         let cancel: &dyn enough::Stop = match self.stop {
             Some(ref s) => s as &dyn enough::Stop,
             None => &enough::Unstoppable,
@@ -1930,12 +1985,12 @@ impl zencodec::decode::Decode for PngDecoder<'_> {
         let effective_limits = self.limits.as_ref().unwrap_or(&self.config.limits);
         effective_limits
             .check_input_size(self.data.len() as u64)
-            .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+            .map_err(|e| at!(PngError::Limit(e)))?;
         // Check max_width / max_height before decoding
         let probe_info = crate::decode::probe(&self.data)?;
         effective_limits
             .check_dimensions(probe_info.width, probe_info.height)
-            .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+            .map_err(|e| at!(PngError::Limit(e)))?;
         let png_config = self.effective_config();
         let result = crate::decode::decode(&self.data, &png_config, cancel)?;
         // Build the probe from decoder state instead of a second full-file
@@ -2020,29 +2075,46 @@ fn push_decoder_native<'a>(
     data: Cow<'a, [u8]>,
     sink: &mut dyn zencodec::decode::DecodeRowSink,
     preferred: &[PixelDescriptor],
-) -> Result<OutputInfo, At<PngError>> {
-    use crate::decoder::postprocess::post_process_row;
-    use crate::decoder::row::RowDecoder;
-
-    let wrap_sink = |e: zencodec::decode::SinkError| -> At<PngError> {
-        at!(PngError::InvalidInput(alloc::format!("sink error: {e}")))
-    };
-
+) -> Result<OutputInfo, At<CodecError>> {
     // Check progressive policy before decoding
-    check_progressive_policy(&data, job.policy.as_ref())?;
+    check_progressive_policy(&data, job.policy.as_ref()).map_err(CodecError::of)?;
 
     // Check input size limit
     let effective_limits = job.limits.as_ref().unwrap_or(&job.config.limits);
     effective_limits
         .check_input_size(data.len() as u64)
-        .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+        .map_err(|e| CodecError::of(at!(PngError::Limit(e))))?;
 
-    // Check for interlacing — fall back to full decode for Adam7
+    // Check for interlacing — fall back to full decode for Adam7. The shared
+    // helper drives the job's trait decode path, so it yields the
+    // `At<CodecError>` envelope directly.
     if data.len() >= 29 && data[..8] == crate::chunk::PNG_SIGNATURE && data[28] == 1 {
         return zencodec::helpers::copy_decode_to_sink(job, data, sink, preferred, |e| {
-            at!(PngError::InvalidInput(alloc::format!("sink error: {e}")))
+            PngError::Io(alloc::format!("sink error: {e}")).into()
         });
     }
+
+    push_decoder_native_noninterlaced(job, data, sink, preferred).map_err(CodecError::of)
+}
+
+/// Non-interlaced native row-streaming decode into the sink, returning the rich
+/// `At<PngError>`; the caller ([`push_decoder_native`]) wraps it into the
+/// `At<CodecError>` envelope.
+fn push_decoder_native_noninterlaced<'a>(
+    job: PngDecodeJob,
+    data: Cow<'a, [u8]>,
+    sink: &mut dyn zencodec::decode::DecodeRowSink,
+    // Native row-streaming emits the PNG's native descriptor; format
+    // negotiation only applies to the interlaced full-decode fallback (handled
+    // by the caller), so the preference list is unused here.
+    _preferred: &[PixelDescriptor],
+) -> Result<OutputInfo, At<PngError>> {
+    use crate::decoder::postprocess::post_process_row;
+    use crate::decoder::row::RowDecoder;
+
+    let wrap_sink = |e: zencodec::decode::SinkError| -> At<PngError> {
+        at!(PngError::Io(alloc::format!("sink error: {e}")))
+    };
 
     // Build effective config (limits + policy)
     let limits = job.limits.as_ref().unwrap_or(&job.config.limits);
@@ -2075,7 +2147,7 @@ fn push_decoder_native<'a>(
     // Check max_width / max_height before allocating pixel buffers
     limits
         .check_dimensions(w, h)
-        .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+        .map_err(|e| at!(PngError::Limit(e)))?;
 
     let descriptor = enrich_descriptor_from_cicp(
         native_output_descriptor(ihdr.color_type, ihdr.bit_depth, has_trns),
@@ -2231,7 +2303,7 @@ impl<'a> PngStreamingDecoder<'a> {
         // Check input size limit
         effective_limits
             .check_input_size(data.len() as u64)
-            .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+            .map_err(|e| at!(PngError::Limit(e)))?;
         let png_config = PngDecodeConfig {
             max_pixels: effective_limits.max_pixels,
             max_memory_bytes: effective_limits.max_memory_bytes,
@@ -2256,7 +2328,7 @@ impl<'a> PngStreamingDecoder<'a> {
         // Check max_width / max_height before allocating pixel buffers
         effective_limits
             .check_dimensions(w, h)
-            .map_err(|e| at!(PngError::LimitExceeded(alloc::format!("{e}"))))?;
+            .map_err(|e| at!(PngError::Limit(e)))?;
 
         let descriptor = enrich_descriptor_from_cicp(
             native_output_descriptor(ihdr.color_type, ihdr.bit_depth, has_trns),
@@ -2285,9 +2357,19 @@ impl<'a> PngStreamingDecoder<'a> {
 }
 
 impl zencodec::decode::StreamingDecode for PngStreamingDecoder<'_> {
-    type Error = At<PngError>;
+    type Error = At<CodecError>;
 
-    fn next_batch(&mut self) -> Result<Option<(u32, PixelSlice<'_>)>, At<PngError>> {
+    fn next_batch(&mut self) -> Result<Option<(u32, PixelSlice<'_>)>, At<CodecError>> {
+        self.next_batch_inner().map_err(CodecError::of)
+    }
+
+    fn info(&self) -> &ImageInfo {
+        &self.info
+    }
+}
+
+impl PngStreamingDecoder<'_> {
+    fn next_batch_inner(&mut self) -> Result<Option<(u32, PixelSlice<'_>)>, At<PngError>> {
         use crate::decoder::postprocess::post_process_row;
 
         if self.y >= self.height {
@@ -2340,10 +2422,6 @@ impl zencodec::decode::StreamingDecode for PngStreamingDecoder<'_> {
         .map_err(|e| at!(PngError::InvalidInput(alloc::format!("pixel slice: {e}"))))?;
 
         Ok(Some((y, slice)))
-    }
-
-    fn info(&self) -> &ImageInfo {
-        &self.info
     }
 }
 
@@ -2413,10 +2491,10 @@ impl PngAnimationFrameDecoder {
 }
 
 impl zencodec::decode::AnimationFrameDecoder for PngAnimationFrameDecoder {
-    type Error = At<PngError>;
+    type Error = At<CodecError>;
 
-    fn wrap_sink_error(err: zencodec::decode::SinkError) -> At<PngError> {
-        at!(PngError::InvalidInput(alloc::format!("sink error: {err}")))
+    fn wrap_sink_error(err: zencodec::decode::SinkError) -> At<CodecError> {
+        PngError::Io(alloc::format!("sink error: {err}")).into()
     }
 
     fn info(&self) -> &ImageInfo {
@@ -2435,14 +2513,14 @@ impl zencodec::decode::AnimationFrameDecoder for PngAnimationFrameDecoder {
         &mut self,
         stop: Option<&dyn enough::Stop>,
         sink: &mut dyn zencodec::decode::DecodeRowSink,
-    ) -> Result<Option<OutputInfo>, At<PngError>> {
+    ) -> Result<Option<OutputInfo>, At<CodecError>> {
         zencodec::helpers::copy_frame_to_sink(self, stop, sink)
     }
 
     fn render_next_frame(
         &mut self,
         stop: Option<&dyn enough::Stop>,
-    ) -> Result<Option<AnimationFrame<'_>>, At<PngError>> {
+    ) -> Result<Option<AnimationFrame<'_>>, At<CodecError>> {
         // Use per-call stop token, fall back to stored job-level token, then unstoppable.
         let cancel: &dyn enough::Stop = if let Some(s) = stop {
             s
@@ -2458,7 +2536,7 @@ impl zencodec::decode::AnimationFrameDecoder for PngAnimationFrameDecoder {
                 self.decoder_state.clone(),
             );
 
-            let raw = match decoder.next_frame(cancel)? {
+            let raw = match decoder.next_frame(cancel).map_err(CodecError::of)? {
                 Some(f) => f,
                 None => return Ok(None),
             };
@@ -2923,9 +3001,10 @@ impl TrueStreamingState {
 
         // PNG chunk lengths are u32. Reject images whose stored IDAT exceeds this.
         if idat_data_len > u32::MAX as usize {
-            return Err(at!(PngError::LimitExceeded(
-                "image too large for single IDAT chunk at effort 0".into(),
-            )));
+            return Err(at!(PngError::Limit(zencodec::LimitExceeded::OutputSize {
+                actual: idat_data_len as u64,
+                max: u32::MAX as u64,
+            })));
         }
 
         // Build metadata
@@ -3606,6 +3685,36 @@ mod tests {
     use rgb::{Gray, Rgb, Rgba};
     use zencodec::decode::{Decode, DecodeJob, DecoderConfig};
     use zencodec::encode::{EncodeJob, EncoderConfig};
+
+    /// Pattern B forcing test: drive the zenpng decoder through the **dyn**
+    /// surface so its `At<CodecError>` is erased to `Box<dyn Error>` (the
+    /// `BoxedError` left after dyn dispatch), and assert a generic consumer
+    /// still recovers the [`ErrorCategory`](zencodec::ErrorCategory) *and* the
+    /// originating codec name. Under the old Pattern A (`type Error =
+    /// At<PngError>`) both would be `None` after erasure — there is no shared
+    /// concrete type to downcast to. This is the regression gate for the
+    /// envelope.
+    #[test]
+    fn envelope_category_survives_dyn_erasure() {
+        use zencodec::decode::DynDecoderConfig;
+        use zencodec::{CodecError, CodecErrorExt, ErrorCategory};
+
+        let cfg = PngDecoderConfig::new();
+        let dyn_cfg: &dyn DynDecoderConfig = &cfg;
+        let erased = dyn_cfg
+            .dyn_job()
+            .probe(b"not a PNG")
+            .expect_err("malformed input must fail to probe");
+
+        // `probe_png` rejects the bad signature with `PngError::Decode`, which
+        // the `CategorizedError` impl maps to `MalformedImage`; the envelope
+        // carries both that category and the codec name through erasure.
+        assert_eq!(erased.error_category(), Some(ErrorCategory::MalformedImage));
+        assert_eq!(
+            erased.codec_error().and_then(CodecError::codec),
+            Some("zenpng")
+        );
+    }
 
     #[test]
     fn encoding_rgb8() {
@@ -5708,12 +5817,16 @@ mod tests {
         use zencodec::encode::Encoder;
         let result = encoder.encode(slice.erase());
         assert!(result.is_err());
-        match result.unwrap_err().decompose().0 {
-            PngError::Stopped(reason) => {
-                assert_eq!(reason, StopReason::Cancelled);
-            }
-            other => panic!("expected PngError::Stopped, got: {other}"),
-        }
+        // Pattern B: `Encoder::encode` returns the `At<CodecError>` envelope, so
+        // the cancellation surfaces as the `Cancelled` category (the faithful
+        // equivalent of the old `PngError::Stopped(StopReason::Cancelled)`).
+        use zencodec::CategorizedError;
+        let err = result.unwrap_err();
+        assert_eq!(
+            err.category(),
+            zencodec::ErrorCategory::Cancelled,
+            "expected a cancellation error, got: {err}"
+        );
     }
 
     #[test]
@@ -7631,12 +7744,15 @@ mod tests {
         // finish() with a cancelled stop token should fail
         let result = enc.finish(Some(&AlreadyCancelled));
         assert!(result.is_err(), "finish with cancelled stop should fail");
-        match result.unwrap_err().decompose().0 {
-            PngError::Stopped(reason) => {
-                assert_eq!(reason, StopReason::Cancelled);
-            }
-            other => panic!("expected PngError::Stopped, got: {other}"),
-        }
+        // Pattern B: `AnimationFrameEncoder::finish` returns the `At<CodecError>`
+        // envelope, so the cancellation surfaces as the `Cancelled` category.
+        use zencodec::CategorizedError;
+        let err = result.unwrap_err();
+        assert_eq!(
+            err.category(),
+            zencodec::ErrorCategory::Cancelled,
+            "expected a cancellation error, got: {err}"
+        );
     }
 
     #[test]

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -351,17 +351,19 @@ impl PngDecodeConfig {
         if let Some(max_px) = self.max_pixels {
             let pixels = width as u64 * height as u64;
             if pixels > max_px {
-                return Err(at!(PngError::LimitExceeded(
-                    "pixel count exceeds limit".into()
-                )));
+                return Err(at!(PngError::Limit(zencodec::LimitExceeded::Pixels {
+                    actual: pixels,
+                    max: max_px,
+                })));
             }
         }
         if let Some(max_mem) = self.max_memory_bytes {
             let estimated = width as u64 * height as u64 * bytes_per_pixel as u64;
             if estimated > max_mem {
-                return Err(at!(PngError::LimitExceeded(
-                    "estimated memory exceeds limit".into(),
-                )));
+                return Err(at!(PngError::Limit(zencodec::LimitExceeded::Memory {
+                    actual: estimated,
+                    max: max_mem,
+                })));
             }
         }
         Ok(())
@@ -580,8 +582,8 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
-            matches!(err.error(), PngError::LimitExceeded(_)),
-            "expected LimitExceeded, got: {err:?}"
+            matches!(err.error(), PngError::Limit(_)),
+            "expected Limit, got: {err:?}"
         );
     }
 
@@ -592,7 +594,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(
-            !matches!(err.error(), PngError::LimitExceeded(_)),
+            !matches!(err.error(), PngError::Limit(_)),
             "expected non-limits error, got: {err:?}"
         );
     }
@@ -603,10 +605,7 @@ mod tests {
         let config = PngDecodeConfig::none().with_max_pixels(5_000);
         let result = decode(&png, &config, &enough::Unstoppable);
         assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err().error(),
-            PngError::LimitExceeded(_)
-        ));
+        assert!(matches!(result.unwrap_err().error(), PngError::Limit(_)));
     }
 
     #[test]
@@ -615,10 +614,7 @@ mod tests {
         let config = PngDecodeConfig::none().with_max_memory(20_000);
         let result = decode(&png, &config, &enough::Unstoppable);
         assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err().error(),
-            PngError::LimitExceeded(_)
-        ));
+        assert!(matches!(result.unwrap_err().error(), PngError::Limit(_)));
     }
 
     #[test]

--- a/src/decoder/apng.rs
+++ b/src/decoder/apng.rs
@@ -93,7 +93,7 @@ impl<'a> ApngDecoder<'a> {
 
         // Parse IHDR
         let (_, ihdr_type, ihdr_data_start, ihdr_crc_end) = read_chunk_header(data, 8)
-            .ok_or_else(|| at!(PngError::Decode("truncated IHDR chunk".into())))?;
+            .ok_or_else(|| at!(PngError::Truncated("truncated IHDR chunk".into())))?;
         if ihdr_type != *b"IHDR" {
             return Err(at!(PngError::Decode("first chunk is not IHDR".into())));
         }
@@ -295,7 +295,7 @@ impl<'a> ApngDecoder<'a> {
                     break;
                 }
                 if decompressor.is_done() {
-                    return Err(at!(PngError::Decode("APNG: truncated IDAT data".into())));
+                    return Err(at!(PngError::Truncated("APNG: truncated IDAT data".into())));
                 }
                 decompressor.fill().map_err(|e| {
                     at!(PngError::Decode(alloc::format!(
@@ -412,7 +412,7 @@ impl<'a> ApngDecoder<'a> {
                     break;
                 }
                 if decompressor.is_done() {
-                    return Err(at!(PngError::Decode("APNG: truncated fdAT data".into())));
+                    return Err(at!(PngError::Truncated("APNG: truncated fdAT data".into())));
                 }
                 decompressor.fill().map_err(|e| {
                     at!(PngError::Decode(alloc::format!(
@@ -534,9 +534,10 @@ pub(crate) fn decode_apng_composed(
         if let Some(max_mem) = config.max_memory_bytes {
             total_frame_bytes = total_frame_bytes.saturating_add(per_frame_bytes);
             if total_frame_bytes > max_mem {
-                return Err(at!(PngError::LimitExceeded(
-                    "cumulative APNG frame memory exceeds limit".into(),
-                )));
+                return Err(at!(PngError::Limit(zencodec::LimitExceeded::Memory {
+                    actual: total_frame_bytes,
+                    max: max_mem,
+                })));
             }
         }
 

--- a/src/decoder/interlace.rs
+++ b/src/decoder/interlace.rs
@@ -72,7 +72,7 @@ pub(crate) fn decode_interlaced(
     // Parse IHDR
     let ihdr_chunk = chunks
         .next()
-        .ok_or_else(|| at!(PngError::Decode("empty PNG".into())))??;
+        .ok_or_else(|| at!(PngError::Truncated("empty PNG".into())))??;
     if ihdr_chunk.chunk_type != *b"IHDR" {
         return Err(at!(PngError::Decode("first chunk is not IHDR".into())));
     }
@@ -115,7 +115,7 @@ pub(crate) fn decode_interlaced(
     // dimensions → default fallible.
     let out_row_bytes = width as usize * fmt.channels * fmt.bytes_per_channel;
     let final_total = out_row_bytes.checked_mul(height as usize).ok_or_else(|| {
-        at!(PngError::InvalidInput(
+        at!(PngError::LimitExceeded(
             "image too large for this platform".into()
         ))
     })?;

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -147,7 +147,7 @@ pub(crate) fn probe_png(data: &[u8]) -> crate::error::Result<PngInfo> {
 
     let ihdr_chunk = chunks
         .next()
-        .ok_or_else(|| at!(PngError::Decode("empty PNG".into())))??;
+        .ok_or_else(|| at!(PngError::Truncated("empty PNG".into())))??;
     if ihdr_chunk.chunk_type != *b"IHDR" {
         return Err(at!(PngError::Decode("first chunk is not IHDR".into())));
     }
@@ -223,7 +223,7 @@ pub(crate) fn decode_png(
     if is_passthrough {
         let raw_row_bytes = ihdr.raw_row_bytes()?;
         let total = raw_row_bytes.checked_mul(h).ok_or_else(|| {
-            at!(PngError::InvalidInput(
+            at!(PngError::LimitExceeded(
                 "image too large for this platform".into()
             ))
         })?;
@@ -350,7 +350,7 @@ pub(crate) fn decode_png(
     let out_row_bytes = w * pixel_bytes;
 
     let out_total = out_row_bytes.checked_mul(h).ok_or_else(|| {
-        at!(PngError::InvalidInput(
+        at!(PngError::LimitExceeded(
             "image too large for this platform".into()
         ))
     })?;
@@ -511,7 +511,9 @@ fn try_decode_stored(
 
     loop {
         if zpos >= zlib_end {
-            return Some(Err(at!(PngError::Decode("truncated stored block".into()))));
+            return Some(Err(at!(PngError::Truncated(
+                "truncated stored block".into()
+            ))));
         }
         let bfinal = zlib[zpos] & 0x01;
         let btype = (zlib[zpos] >> 1) & 0x03;

--- a/src/decoder/postprocess.rs
+++ b/src/decoder/postprocess.rs
@@ -452,7 +452,7 @@ impl OutputFormat {
                 }
             }
             _ => {
-                return Err(at!(PngError::Decode(alloc::format!(
+                return Err(at!(PngError::UnsupportedFeature(alloc::format!(
                     "unsupported color_type {} in IHDR",
                     ihdr.color_type
                 ))));
@@ -559,7 +559,7 @@ pub(crate) fn build_pixel_data(
             Ok(PixelBuffer::from_pixels_erased(rgba, w32, h32)
                 .map_err(|e| at!(PngError::Decode(alloc::format!("{e}"))))?)
         }
-        _ => Err(at!(PngError::Decode(alloc::format!(
+        _ => Err(at!(PngError::UnsupportedFeature(alloc::format!(
             "unsupported color_type={} bit_depth={}",
             ihdr.color_type,
             ihdr.bit_depth

--- a/src/decoder/row.rs
+++ b/src/decoder/row.rs
@@ -53,7 +53,7 @@ impl<'a> IdatSource<'a> {
         // 32-bit-clean even if a caller ever passes an unvalidated offset.
         let length_bytes: [u8; 4] = data
             .get(first_idat_pos..first_idat_pos + 4)
-            .ok_or_else(|| PngError::Decode("truncated IDAT chunk header (length)".into()))?
+            .ok_or_else(|| PngError::Truncated("truncated IDAT chunk header (length)".into()))?
             .try_into()
             .unwrap(); // infallible: slice is exactly 4 bytes
         let length = u32::from_be_bytes(length_bytes) as usize;
@@ -66,10 +66,10 @@ impl<'a> IdatSource<'a> {
             .ok_or_else(|| PngError::Decode("IDAT chunk length overflow".into()))?; // skip CRC
 
         if data_end > data.len() {
-            return Err(PngError::Decode("truncated IDAT chunk data".into()));
+            return Err(PngError::Truncated("truncated IDAT chunk data".into()));
         }
         if next_pos > data.len() {
-            return Err(PngError::Decode("truncated IDAT chunk CRC".into()));
+            return Err(PngError::Truncated("truncated IDAT chunk CRC".into()));
         }
 
         Ok(Self {
@@ -120,7 +120,7 @@ impl zenflate::InputSource for IdatSource<'_> {
             };
 
             if crc_end > self.data.len() {
-                return Err(PngError::Decode("truncated IDAT chunk".into()));
+                return Err(PngError::Truncated("truncated IDAT chunk".into()));
             }
 
             if chunk_type != *b"IDAT" {
@@ -182,7 +182,7 @@ impl<'a> FdatSource<'a> {
         // Parse the first fdAT chunk inline
         let length_bytes: [u8; 4] = data
             .get(first_fdat_pos..first_fdat_pos + 4)
-            .ok_or_else(|| PngError::Decode("truncated fdAT chunk header (length)".into()))?
+            .ok_or_else(|| PngError::Truncated("truncated fdAT chunk header (length)".into()))?
             .try_into()
             .unwrap(); // infallible: slice is exactly 4 bytes
         let length = u32::from_be_bytes(length_bytes) as usize;
@@ -195,10 +195,10 @@ impl<'a> FdatSource<'a> {
             .ok_or_else(|| PngError::Decode("fdAT chunk length overflow".into()))?;
 
         if data_end > data.len() {
-            return Err(PngError::Decode("truncated fdAT chunk data".into()));
+            return Err(PngError::Truncated("truncated fdAT chunk data".into()));
         }
         if next_pos > data.len() {
-            return Err(PngError::Decode("truncated fdAT chunk CRC".into()));
+            return Err(PngError::Truncated("truncated fdAT chunk CRC".into()));
         }
 
         // Skip the 4-byte sequence number to get to deflate data
@@ -256,7 +256,7 @@ impl<'a> zenflate::InputSource for FdatSource<'a> {
             };
 
             if crc_end > self.data.len() {
-                return Err(PngError::Decode("truncated fdAT chunk".into()));
+                return Err(PngError::Truncated("truncated fdAT chunk".into()));
             }
 
             if chunk_type != *b"fdAT" {
@@ -353,7 +353,7 @@ impl<'a> RowDecoder<'a> {
         // First chunk must be IHDR
         let ihdr_chunk = chunks
             .next()
-            .ok_or_else(|| at!(PngError::Decode("empty PNG (no chunks)".into())))??;
+            .ok_or_else(|| at!(PngError::Truncated("empty PNG (no chunks)".into())))??;
         if ihdr_chunk.chunk_type != *b"IHDR" {
             return Err(at!(PngError::Decode("first chunk is not IHDR".into())));
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,26 +6,90 @@ use whereat::At;
 pub type Result<T> = core::result::Result<T, At<PngError>>;
 
 /// Errors from PNG encode/decode operations.
+///
+/// Each variant maps to exactly one coarse [`zencodec::ErrorCategory`] (see the
+/// [`CategorizedError`](zencodec::CategorizedError) impl) so consumers can route
+/// on the category — HTTP status, retry policy, logging — without matching this
+/// enum directly.
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum PngError {
-    /// PNG decoding error.
+    /// Corrupt or invalid PNG bitstream content (bad chunk, CRC mismatch,
+    /// invalid structure). Maps to [`ErrorCategory::MalformedImage`].
+    ///
+    /// [`ErrorCategory::MalformedImage`]: zencodec::ErrorCategory::MalformedImage
     #[error("PNG decode error: {0}")]
     Decode(alloc::string::String),
 
-    /// Invalid input (dimensions, buffer size, etc.).
+    /// Input ended before a needed field/chunk was complete (truncated stream,
+    /// missing IDAT, empty PNG). Maps to [`ErrorCategory::UnexpectedEof`].
+    ///
+    /// [`ErrorCategory::UnexpectedEof`]: zencodec::ErrorCategory::UnexpectedEof
+    #[error("unexpected end of PNG data: {0}")]
+    Truncated(alloc::string::String),
+
+    /// A structurally-valid PNG feature this codec does not implement
+    /// (unknown filter type, unsupported color-type/bit-depth combination).
+    /// Maps to [`ErrorCategory::UnsupportedImageFeature`].
+    ///
+    /// [`ErrorCategory::UnsupportedImageFeature`]: zencodec::ErrorCategory::UnsupportedImageFeature
+    #[error("unsupported PNG feature: {0}")]
+    UnsupportedFeature(alloc::string::String),
+
+    /// Invalid caller-supplied parameters or configuration (bad dimensions,
+    /// inconsistent streaming usage, quantizer config, mismatched buffer size).
+    /// Maps to [`ErrorCategory::InvalidParameters`].
+    ///
+    /// [`ErrorCategory::InvalidParameters`]: zencodec::ErrorCategory::InvalidParameters
     #[error("invalid input: {0}")]
     InvalidInput(alloc::string::String),
 
-    /// Resource limit exceeded.
+    /// An unsupported operation, including pixel-format negotiation failures.
+    /// Delegates its category to the wrapped [`zencodec::UnsupportedOperation`]
+    /// (`PixelFormat` → [`ErrorCategory::UnsupportedPixelFormat`], otherwise
+    /// [`ErrorCategory::UnsupportedOperation`]).
+    ///
+    /// [`ErrorCategory::UnsupportedPixelFormat`]: zencodec::ErrorCategory::UnsupportedPixelFormat
+    /// [`ErrorCategory::UnsupportedOperation`]: zencodec::ErrorCategory::UnsupportedOperation
+    #[error("unsupported operation: {0}")]
+    Unsupported(zencodec::UnsupportedOperation),
+
+    /// Output sink / I/O write failure. Maps to [`ErrorCategory::Io`].
+    ///
+    /// [`ErrorCategory::Io`]: zencodec::ErrorCategory::Io
+    #[error("I/O error: {0}")]
+    Io(alloc::string::String),
+
+    /// A configured resource limit was exceeded. Wraps the typed
+    /// [`zencodec::LimitExceeded`] so the [`LimitKind`](zencodec::LimitKind) is
+    /// preserved; delegates its category to
+    /// [`ErrorCategory::LimitsExceeded`]`(kind)`.
+    ///
+    /// [`ErrorCategory::LimitsExceeded`]: zencodec::ErrorCategory::LimitsExceeded
+    #[error("resource limit exceeded: {0}")]
+    Limit(zencodec::LimitExceeded),
+
+    /// Memory acquisition failed: a fallible allocation returned an error, or a
+    /// size computation overflowed the platform's address space (so the buffer
+    /// can never be allocated). Maps to [`ErrorCategory::OutOfMemory`].
+    ///
+    /// [`ErrorCategory::OutOfMemory`]: zencodec::ErrorCategory::OutOfMemory
     #[error("limit exceeded: {0}")]
     LimitExceeded(alloc::string::String),
 
-    /// Operation stopped by cooperative cancellation.
+    /// Operation stopped by cooperative cancellation. Delegates its category to
+    /// the wrapped [`enough::StopReason`] (`TimedOut` →
+    /// [`ErrorCategory::TimedOut`], otherwise [`ErrorCategory::Cancelled`]).
+    ///
+    /// [`ErrorCategory::TimedOut`]: zencodec::ErrorCategory::TimedOut
+    /// [`ErrorCategory::Cancelled`]: zencodec::ErrorCategory::Cancelled
     #[error("stopped: {0}")]
     Stopped(enough::StopReason),
 
-    /// Quantization error (zenquant backend).
+    /// Quantization error (zenquant backend). Maps to
+    /// [`ErrorCategory::Internal`].
+    ///
+    /// [`ErrorCategory::Internal`]: zencodec::ErrorCategory::Internal
     #[cfg(feature = "quantize")]
     #[error("quantize error: {0}")]
     Quantize(#[from] zenquant::QuantizeError),
@@ -39,7 +103,100 @@ impl From<enough::StopReason> for PngError {
 
 impl From<zencodec::UnsupportedOperation> for PngError {
     fn from(op: zencodec::UnsupportedOperation) -> Self {
-        PngError::InvalidInput(alloc::format!("unsupported operation: {op}"))
+        PngError::Unsupported(op)
+    }
+}
+
+impl From<zencodec::LimitExceeded> for PngError {
+    fn from(limit: zencodec::LimitExceeded) -> Self {
+        PngError::Limit(limit)
+    }
+}
+
+// Codec-agnostic error taxonomy (zencodec PR #103). Maps every `PngError`
+// variant to exactly one coarse `ErrorCategory` so consumers can route on the
+// category without naming this enum. `zencodec` is a non-optional dependency, so
+// this impl is unconditional.
+impl zencodec::CategorizedError for PngError {
+    fn codec_name(&self) -> Option<&'static str> {
+        Some("zenpng")
+    }
+
+    fn category(&self) -> zencodec::ErrorCategory {
+        use zencodec::ErrorCategory as C;
+        match self {
+            // Corrupt / invalid bitstream content.
+            PngError::Decode(_) => C::MalformedImage,
+
+            // Truncated input / unexpected end of data.
+            PngError::Truncated(_) => C::UnexpectedEof,
+
+            // A valid PNG feature we don't implement.
+            PngError::UnsupportedFeature(_) => C::UnsupportedImageFeature,
+
+            // Bad caller parameters / configuration / usage.
+            PngError::InvalidInput(_) => C::InvalidParameters,
+
+            // Output sink / I/O failures.
+            PngError::Io(_) => C::Io(zencodec::CodecIoKind::opaque()),
+
+            // Memory acquisition failure (alloc failed or address-space overflow).
+            PngError::LimitExceeded(_) => C::OutOfMemory,
+
+            // Delegate to the wrapped zencodec cause types — they carry their
+            // own `CategorizedError` impl (kind / pixel-format / stop-reason).
+            PngError::Unsupported(op) => op.category(),
+            PngError::Limit(limit) => limit.category(),
+            PngError::Stopped(reason) => reason.category(),
+
+            // Quantizer backend failure. Delegating would need zenquant itself
+            // to impl `CategorizedError` (out of scope here); treat as internal.
+            #[cfg(feature = "quantize")]
+            PngError::Quantize(_) => C::Internal,
+        }
+    }
+}
+
+/// Categorize a [`ProbeError`]: structural pre-decode probe failures.
+///
+/// `ProbeError` is caller-facing (returned by [`crate::detect::probe`]), so it
+/// carries its own [`CategorizedError`](zencodec::CategorizedError) impl too.
+impl zencodec::CategorizedError for crate::detect::ProbeError {
+    fn codec_name(&self) -> Option<&'static str> {
+        Some("zenpng")
+    }
+
+    fn category(&self) -> zencodec::ErrorCategory {
+        use crate::detect::ProbeError;
+        use zencodec::ErrorCategory as C;
+        match self {
+            // Not enough bytes yet / structure cut short → need more input.
+            ProbeError::TooShort | ProbeError::Truncated => C::UnexpectedEof,
+            // Signature absent → this isn't a PNG at all.
+            ProbeError::NotPng => C::UnsupportedImageType,
+        }
+    }
+}
+
+/// Bridge a bare [`PngError`] into the shared
+/// [`CodecError`](zencodec::CodecError) envelope (Pattern B).
+///
+/// `.start_at()` begins the location trace; [`CodecError::of`] then reads the
+/// [`category`](zencodec::CategorizedError::category) *and* the
+/// [`codec_name`](zencodec::CategorizedError::codec_name) from the value, keeping
+/// the trace on the outside. With this, `?`/`.into()` on a bare `PngError`
+/// auto-wraps into the envelope the zencodec trait impls return.
+///
+/// Already-located `At<PngError>` values convert via `.map_err(CodecError::of)`
+/// instead — the orphan rule forbids a `From<At<PngError>>` impl here (`At` is
+/// not a fundamental type, so `At<PngError>` is not a local type).
+///
+/// [`CodecError::of`]: zencodec::CodecError::of
+impl From<PngError> for At<zencodec::CodecError> {
+    #[track_caller]
+    fn from(e: PngError) -> Self {
+        use whereat::ErrorAtExt;
+        zencodec::CodecError::of(e.start_at())
     }
 }
 
@@ -47,6 +204,7 @@ impl From<zencodec::UnsupportedOperation> for PngError {
 mod tests {
     use super::*;
     use whereat::at;
+    use zencodec::{CategorizedError, ErrorCategory as C, LimitKind as L};
 
     #[test]
     fn error_display_decode() {
@@ -77,7 +235,15 @@ mod tests {
     fn error_from_unsupported_operation() {
         let op = zencodec::UnsupportedOperation::RowLevelEncode;
         let e: PngError = op.into();
+        assert!(matches!(e, PngError::Unsupported(_)));
         assert!(e.to_string().contains("unsupported operation"));
+    }
+
+    #[test]
+    fn error_from_limit_exceeded() {
+        let limit = zencodec::LimitExceeded::Pixels { actual: 9, max: 4 };
+        let e: PngError = limit.into();
+        assert!(matches!(e, PngError::Limit(_)));
     }
 
     #[test]
@@ -93,5 +259,82 @@ mod tests {
 
         let err = outer().unwrap_err();
         assert!(err.frame_count() >= 1);
+    }
+
+    // Every `PngError` variant maps to its documented `ErrorCategory`.
+    #[test]
+    fn error_category_mapping() {
+        assert_eq!(PngError::Decode("x".into()).codec_name(), Some("zenpng"));
+
+        assert_eq!(PngError::Decode("x".into()).category(), C::MalformedImage);
+        assert_eq!(PngError::Truncated("x".into()).category(), C::UnexpectedEof);
+        assert_eq!(
+            PngError::UnsupportedFeature("x".into()).category(),
+            C::UnsupportedImageFeature
+        );
+        assert_eq!(
+            PngError::InvalidInput("x".into()).category(),
+            C::InvalidParameters
+        );
+        assert_eq!(
+            PngError::Io("x".into()).category(),
+            C::Io(zencodec::CodecIoKind::opaque())
+        );
+        assert_eq!(
+            PngError::LimitExceeded("x".into()).category(),
+            C::OutOfMemory
+        );
+
+        // Delegated arms.
+        assert_eq!(
+            PngError::Unsupported(zencodec::UnsupportedOperation::PixelFormat).category(),
+            C::UnsupportedPixelFormat
+        );
+        assert_eq!(
+            PngError::Unsupported(zencodec::UnsupportedOperation::RowLevelEncode).category(),
+            C::UnsupportedOperation
+        );
+        assert_eq!(
+            PngError::Limit(zencodec::LimitExceeded::Memory { actual: 9, max: 4 }).category(),
+            C::LimitsExceeded(L::Memory)
+        );
+        assert_eq!(
+            PngError::Limit(zencodec::LimitExceeded::Frames { actual: 9, max: 4 }).category(),
+            C::LimitsExceeded(L::Frames)
+        );
+        assert_eq!(
+            PngError::Stopped(enough::StopReason::Cancelled).category(),
+            C::Cancelled
+        );
+        assert_eq!(
+            PngError::Stopped(enough::StopReason::TimedOut).category(),
+            C::TimedOut
+        );
+    }
+
+    // `At<PngError>` forwards both the category and the codec name.
+    #[test]
+    fn error_category_through_at() {
+        let err: At<PngError> = at!(PngError::Truncated("eof".into()));
+        assert_eq!(err.category(), C::UnexpectedEof);
+        assert_eq!(err.codec_name(), Some("zenpng"));
+    }
+
+    #[test]
+    #[cfg(feature = "quantize")]
+    fn error_quantize_is_internal() {
+        let e: PngError = zenquant::QuantizeError::ZeroDimension.into();
+        assert!(matches!(e, PngError::Quantize(_)));
+        assert_eq!(e.category(), C::Internal);
+    }
+
+    // ProbeError categories.
+    #[test]
+    fn probe_error_category_mapping() {
+        use crate::detect::ProbeError;
+        assert_eq!(ProbeError::TooShort.codec_name(), Some("zenpng"));
+        assert_eq!(ProbeError::TooShort.category(), C::UnexpectedEof);
+        assert_eq!(ProbeError::Truncated.category(), C::UnexpectedEof);
+        assert_eq!(ProbeError::NotPng.category(), C::UnsupportedImageType);
     }
 }

--- a/tests/sweep_validate.rs
+++ b/tests/sweep_validate.rs
@@ -15,7 +15,7 @@
 
 use imgref::ImgRef;
 use rgb::Rgb;
-use zenpng::sweep::{SweepAxes, plan};
+use zenpng::sweep::{QuantBackend, SweepAxes, plan};
 use zenpng::{DowncastFlags, PngDecodeConfig, decode, encode_rgb8};
 
 struct Image {
@@ -111,12 +111,26 @@ fn corpus() -> Vec<Image> {
 fn sweep_cells_decode_exactly_and_steps_are_live() {
     let p = plan(&SweepAxes::modes_full());
     assert_eq!(p.cells[0].id, "png-balanced");
+    // The plan always carries every quantize cell (see
+    // `modes_full_has_all_eight_quantize_cells`), but a cell can only be
+    // *encoded* when its backend's feature is compiled in. Drop the cells whose
+    // backend is absent in this build so the matrix below stays aligned; the CI
+    // feature matrix exercises every backend in the jobs where it is enabled.
+    let cells: Vec<_> = p
+        .cells
+        .iter()
+        .filter(|c| match c.variant.quantize.as_ref().map(|q| q.backend) {
+            None => true,
+            Some(QuantBackend::Imagequant) => cfg!(feature = "imagequant"),
+            Some(QuantBackend::Zenquant) => cfg!(feature = "quantize"),
+        })
+        .collect();
     let images = corpus();
     let mut failures: Vec<String> = Vec::new();
     // bytes[cell][image]
     let mut bytes: Vec<Vec<usize>> = Vec::new();
 
-    for cell in &p.cells {
+    for cell in &cells {
         let is_lossy = cell.variant.quantize.is_some();
         let mut row = Vec::new();
         for img in &images {
@@ -162,7 +176,7 @@ fn sweep_cells_decode_exactly_and_steps_are_live() {
 
     // Step liveness: every non-default tier must change bytes vs the
     // default somewhere in the corpus.
-    for (ci, cell) in p.cells.iter().enumerate().skip(1) {
+    for (ci, cell) in cells.iter().enumerate().skip(1) {
         if bytes[ci] == bytes[0] {
             failures.push(format!(
                 "INERT STEP: {} byte-matched png-balanced on every image",
@@ -173,7 +187,7 @@ fn sweep_cells_decode_exactly_and_steps_are_live() {
     // Soft sanity, hard-checked at the extremes: None is the largest
     // tier everywhere; Intense never loses to Fastest on compressible
     // content.
-    let idx = |id: &str| p.cells.iter().position(|c| c.id == id).unwrap();
+    let idx = |id: &str| cells.iter().position(|c| c.id == id).unwrap();
     let (none_i, fastest_i, intense_i) = (idx("png-none"), idx("png-fastest"), idx("png-intense"));
     for (ii, img) in images.iter().enumerate() {
         if bytes[none_i][ii] < bytes[fastest_i][ii] {


### PR DESCRIPTION
Adopts the zencodec `CategorizedError` taxonomy (PR imazen/zencodec#103) and — because the inventory flagged zenpng's errors as stringly-typed — **splits the catch-all variants into discrete, category-named ones and wires them at the real construction sites** (41 sites).

## Error-type expansion (additive on `#[non_exhaustive]`)
The opaque `Decode(String)` / `InvalidInput(String)` / `LimitExceeded(String)` bundled several categories. Now:
- `Decode(String)` → kept for corrupt bitstream content (→ `MalformedImage`).
- **new `Truncated(String)`** → input ended early / truncated chunk / missing IDAT (→ `UnexpectedEof`).
- **new `UnsupportedFeature(String)`** → a structurally-valid PNG feature not implemented (→ `UnsupportedImageFeature`).
- `InvalidInput(String)` → narrowed to caller config/params (→ `InvalidParameters`).
- **new `Unsupported(zencodec::UnsupportedOperation)`** → API/op + pixel-format negotiation, delegates (`PixelFormat` → `UnsupportedPixelFormat`).
- **new `Limit(zencodec::LimitExceeded)`** → resource caps, delegates so the exact `LimitKind` is preserved (the old stringly limit lost it).
- `LimitExceeded(String)` → kept for alloc/address-space failures (→ `OutOfMemory`).
- `Stopped(StopReason)` → delegates (`Cancelled`/`TimedOut`).
- `Quantize` → `Internal` (delegating needs zenquant to impl `CategorizedError` — follow-up).

## CategorizedError
`impl CategorizedError for PngError` and `ProbeError` (`CODEC_NAME = "zenpng"`, total `category()`, delegating to the wrapped zencodec cause types). New error sites use whereat (`at!(PngError::…)`). Unit test maps every variant + the `At<E>` forward + `CODEC_NAME`.

## Temp dependency
`[patch.crates-io] zencodec = { git, branch = "cancellation-classification-99" }` — **TEMP until zencodec 0.1.26 ships (PR #103)**; remove + bump the version then.

Gate: fmt clean; clippy `-D warnings` clean (default + `zencodec`); `cargo test --features zencodec` green.
