### PR TITLE
feat: typed one-shot zenpng::encode(PixelSlice) + decode_rgba8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to zenpng are documented here.
 ## [Unreleased]
 
 ### Added
+- **One-shot convenience functions: `encode` + `decode_rgba8`.** Purely-additive
+  top-level free functions for the two most common jobs in a single call:
+  `encode(img: zenpixels::PixelSlice<'_>) -> Result<Vec<u8>>` encodes a
+  self-describing pixel slice (format, dimensions, and row stride ride *with* the
+  pixels — no separate `width`/`height` args and no buffer-length-mismatch class
+  of bug) at the default `PngEncoderConfig`, and
+  `decode_rgba8(&png) -> Result<(Vec<u8>, u32, u32)>` decodes any PNG to packed
+  RGBA8 + dimensions (normalizing grayscale / indexed / RGB / 16-bit sources to
+  8-bit RGBA). Both wrap the existing builder path, so the full power API (custom
+  filter/effort, metadata, 16-bit, cancellation) is unchanged. README quick-start
+  leads with these; each fn carries the round-trip as a runnable doctest.
 - **Palette/quantize axis on the sweep plan (`sweep::QuantizeSpec` +
   `QuantBackend`).** `SweepVariant` gains an optional `quantize` stratum:
   `None` = truecolor lossless (unchanged), `Some(spec)` = palette-reduce to

--- a/README.crates.md
+++ b/README.crates.md
@@ -11,6 +11,45 @@ reduction by [zenquant](https://github.com/imazen/zenquant).
 
 ## Quick start
 
+The one-shot path needs only `zenpng` + `zenpixels`: wrap your pixels in a
+self-describing `PixelSlice` (it carries the pixel format, dimensions, and row
+stride) and encode to a PNG, then decode any PNG back to packed RGBA8 +
+dimensions — each in a single call.
+
+```toml
+[dependencies]
+zenpng = "0.1"
+zenpixels = "0.2"
+```
+
+```rust
+use zenpng::{encode, decode_rgba8};
+use zenpixels::{PixelSlice, PixelDescriptor};
+
+// 2×2 RGBA, tightly packed — dims + stride + format ride with the pixels.
+let (width, height) = (2u32, 2u32);
+let rgba = vec![
+    255, 0, 0, 255,    0, 255, 0, 255,
+    0, 0, 255, 255,    255, 255, 255, 255,
+];
+let img = PixelSlice::new(&rgba, width, height, width as usize * 4, PixelDescriptor::RGBA8_SRGB)?;
+
+let png = encode(img)?; // no separate width/height arguments
+let (pixels, w, h) = decode_rgba8(&png)?;
+
+assert_eq!((w, h), (width, height));
+assert_eq!(pixels, rgba); // PNG is lossless — exact round-trip
+```
+
+`encode` accepts any `PixelSlice` format (RGB8, grayscale, 16-bit, …) — the
+descriptor rides with the pixels. `decode_rgba8` normalizes grayscale / indexed
+/ RGB / 16-bit sources to 8-bit RGBA (opaque sources get `A = 255`). For a
+specific filter/effort, embedded ICC/EXIF/XMP, 16-bit / grayscale / indexed I/O,
+resource limits, or cooperative cancellation, drop down to the typed builder API
+below.
+
+### Power API — builder & typed buffers
+
 ```toml
 [dependencies]
 zenpng = "0.1"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,45 @@ reduction by [zenquant](https://github.com/imazen/zenquant).
 
 ## Quick start
 
+The one-shot path needs only `zenpng` + `zenpixels`: wrap your pixels in a
+self-describing `PixelSlice` (it carries the pixel format, dimensions, and row
+stride) and encode to a PNG, then decode any PNG back to packed RGBA8 +
+dimensions — each in a single call.
+
+```toml
+[dependencies]
+zenpng = "0.1"
+zenpixels = "0.2"
+```
+
+```rust
+use zenpng::{encode, decode_rgba8};
+use zenpixels::{PixelSlice, PixelDescriptor};
+
+// 2×2 RGBA, tightly packed — dims + stride + format ride with the pixels.
+let (width, height) = (2u32, 2u32);
+let rgba = vec![
+    255, 0, 0, 255,    0, 255, 0, 255,
+    0, 0, 255, 255,    255, 255, 255, 255,
+];
+let img = PixelSlice::new(&rgba, width, height, width as usize * 4, PixelDescriptor::RGBA8_SRGB)?;
+
+let png = encode(img)?; // no separate width/height arguments
+let (pixels, w, h) = decode_rgba8(&png)?;
+
+assert_eq!((w, h), (width, height));
+assert_eq!(pixels, rgba); // PNG is lossless — exact round-trip
+```
+
+`encode` accepts any `PixelSlice` format (RGB8, grayscale, 16-bit, …) — the
+descriptor rides with the pixels. `decode_rgba8` normalizes grayscale / indexed
+/ RGB / 16-bit sources to 8-bit RGBA (opaque sources get `A = 255`). For a
+specific filter/effort, embedded ICC/EXIF/XMP, 16-bit / grayscale / indexed I/O,
+resource limits, or cooperative cancellation, drop down to the typed builder API
+below.
+
+### Power API — builder & typed buffers
+
 ```toml
 [dependencies]
 zenpng = "0.1"

--- a/docs/public-api/zenpng.txt
+++ b/docs/public-api/zenpng.txt
@@ -6,14 +6,14 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: zenpng.txt 417 lines (supported surface) | zenpng.features.txt 21 added (features: avx512,cms,imagequant,joint,quantette,quantize,unchecked,zencodec,zopfli) | zenpng.internal.txt 97 lines (117 hidden + 34 excluded-feature)
+# files: zenpng.txt 419 lines (supported surface) | zenpng.features.txt 21 added (features: avx512,cms,imagequant,joint,quantette,quantize,unchecked,zencodec,zopfli) | zenpng.internal.txt 97 lines (117 hidden + 34 excluded-feature)
 
 ## summary
 #
 #   pub modules                                 4
 #   pub types (struct/enum/trait/alias)        49
 #   pub consts/statics                          9
-#   free functions                             27
+#   free functions                             29
 #   inherent methods                           68
 #   struct fields                             151
 #   enum variants                              56
@@ -22,12 +22,12 @@
 #   auto-trait exceptions                       6
 #
 # per-module pub lines:
-#   (root)                          277
+#   (root)                          279
 #   detect                           41
 #   heuristics                       13
 #   sweep                            33
 
-## items (364 lines)
+## items (366 lines)
 
 pub mod zenpng
 pub mod detect
@@ -378,7 +378,9 @@ pub fn Quantizer::with_quality_metrics(&self) -> core::option::Option<alloc::box
 pub fn available_backends() -> &'static [&'static str]
 pub fn decode(&[u8], &PngDecodeConfig, &dyn enough::Stop) -> core::result::Result<PngDecodeOutput, whereat::at::At<PngError>>
 pub fn decode_apng(&[u8], &PngDecodeConfig, &dyn enough::Stop) -> core::result::Result<ApngDecodeOutput, whereat::at::At<PngError>>
+pub fn decode_rgba8(&[u8]) -> core::result::Result<(alloc::vec::Vec<u8>, u32, u32), whereat::at::At<PngError>>
 pub fn default_quantizer() -> alloc::boxed::Box<dyn Quantizer>
+pub fn encode(zenpixels::buffer::PixelSlice<'_>) -> core::result::Result<alloc::vec::Vec<u8>, whereat::at::At<PngError>>
 pub fn encode_apng(&[ApngFrameInput<'_>], u32, u32, &ApngEncodeConfig, core::option::Option<&zencodec::metadata::Metadata>, &dyn enough::Stop, &dyn enough::Stop) -> core::result::Result<alloc::vec::Vec<u8>, whereat::at::At<PngError>>
 pub fn encode_apng_auto(&ApngEncodeParams<'_>, QualityGate) -> core::result::Result<AutoEncodeResult, whereat::at::At<PngError>>
 pub fn encode_apng_indexed(&ApngEncodeParams<'_>) -> core::result::Result<alloc::vec::Vec<u8>, whereat::at::At<PngError>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,6 +108,115 @@ pub use quantize::{
 
 pub use types::{Compression, Filter};
 
+// ---------------------------------------------------------------------------
+// One-shot convenience functions
+//
+// The shortest path for the two most common jobs — encode a self-describing
+// pixel slice to a PNG, and decode any PNG back to tightly-packed RGBA8 +
+// dimensions — with sane defaults, for someone who hasn't read the rest of the
+// docs. Both are purely additive wrappers over the builder/config path.
+//
+// The encode input is a [`zenpixels::PixelSlice`]: it carries the pixel format,
+// width, height, and row stride, so the dimensions ride *with* the pixels —
+// there is no separate width/height to keep in sync and no buffer-length
+// mismatch to guard against. Reach for [`PngEncoderConfig`] / [`EncodeConfig`]
+// (a specific filter/effort, embedded ICC/EXIF/XMP, resource limits,
+// cancellation) or [`decode`] / [`PngDecodeConfig`] (16-bit output, the native
+// pixel buffer, decode warnings, strict checksums) when you need more control.
+// ---------------------------------------------------------------------------
+
+/// Encode a [`zenpixels::PixelSlice`] to a PNG in one call.
+///
+/// The slice is self-describing: it carries the pixel format (RGBA8, RGB8,
+/// grayscale, 16-bit, …), the dimensions, and the row stride, so there is no
+/// separate `width`/`height` argument to keep in sync and no buffer-length
+/// mismatch to guard against — strided slices are handled directly. Uses the
+/// default [`PngEncoderConfig`] (balanced lossless compression, no embedded
+/// metadata). For a specific filter/effort, embedded ICC/EXIF/XMP, or resource
+/// limits / cancellation, build a [`PngEncoderConfig`] / [`EncodeConfig`] and
+/// drive the encode job directly.
+///
+/// # Errors
+/// Returns a [`PngError`] if the slice's pixel format is not supported by the
+/// PNG encoder, plus any encode error bubbled up from the underlying pipeline.
+///
+/// ```
+/// use zenpng::{encode, decode_rgba8};
+/// use zenpixels::{PixelSlice, PixelDescriptor};
+///
+/// // 2×2 RGBA, tightly packed — dims + stride + format ride with the pixels.
+/// let (width, height) = (2u32, 2u32);
+/// let rgba = vec![
+///     255, 0, 0, 255,    0, 255, 0, 255,
+///     0, 0, 255, 255,    255, 255, 255, 255,
+/// ];
+/// let img = PixelSlice::new(&rgba, width, height, width as usize * 4, PixelDescriptor::RGBA8_SRGB)?;
+///
+/// let png = encode(img)?; // no separate width/height arguments
+/// let (pixels, w, h) = decode_rgba8(&png)?;
+///
+/// assert_eq!((w, h), (width, height));
+/// assert_eq!(pixels, rgba); // PNG is lossless — exact round-trip
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn encode(img: zenpixels::PixelSlice<'_>) -> crate::error::Result<Vec<u8>> {
+    use zencodec::encode::{EncodeJob, Encoder, EncoderConfig};
+    let output = crate::PngEncoderConfig::default()
+        .job()
+        .encoder()?
+        .encode(img)?;
+    Ok(output.into_vec())
+}
+
+/// Decode a PNG (any color type / bit depth) to tightly-packed 8-bit RGBA in
+/// one call.
+///
+/// Returns `(rgba, width, height)` where `rgba` is exactly `width * height * 4`
+/// bytes (`R, G, B, A` per pixel, no stride padding). Grayscale, indexed, RGB
+/// and 16-bit sources are all normalized to 8-bit RGBA; opaque sources get
+/// `A = 255`. Uses the default [`PngDecodeConfig`] (checksums skipped for
+/// speed, default resource limits). For 16-bit output, the native pixel buffer,
+/// decode warnings, or strict checksum verification, use [`decode`] /
+/// [`PngDecodeConfig`].
+///
+/// # Errors
+/// Returns a [`PngError`] if `png` is not a valid PNG or a resource limit is
+/// exceeded.
+///
+/// ```
+/// use zenpng::{encode, decode_rgba8};
+/// use zenpixels::{PixelSlice, PixelDescriptor};
+///
+/// // 2×2 RGBA, tightly packed — dims + stride + format ride with the pixels.
+/// let (width, height) = (2u32, 2u32);
+/// let rgba = vec![
+///     255, 0, 0, 255,    0, 255, 0, 255,
+///     0, 0, 255, 255,    255, 255, 255, 255,
+/// ];
+/// let img = PixelSlice::new(&rgba, width, height, width as usize * 4, PixelDescriptor::RGBA8_SRGB)?;
+///
+/// let png = encode(img)?;
+/// let (pixels, w, h) = decode_rgba8(&png)?;
+///
+/// assert_eq!((w, h), (width, height));
+/// assert_eq!(pixels, rgba); // PNG is lossless — exact round-trip
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+pub fn decode_rgba8(png: &[u8]) -> crate::error::Result<(Vec<u8>, u32, u32)> {
+    use zenpixels_convert::PixelBufferConvertTypedExt as _;
+    let output = crate::decode::decode(
+        png,
+        &crate::PngDecodeConfig::default(),
+        &enough::Unstoppable,
+    )?;
+    let width = output.info.width;
+    let height = output.info.height;
+    // `to_rgba8()` normalizes any native color type to RGBA8;
+    // `copy_to_contiguous_bytes()` strips any stride padding.
+    let rgba = output.pixels.to_rgba8().copy_to_contiguous_bytes();
+    Ok((rgba, width, height))
+}
+
 #[cfg(feature = "_dev")]
 #[doc(hidden)]
 pub use crate::encode::{encode_rgb8_with_stats, encode_rgba8_with_stats};


### PR DESCRIPTION
Redesigned one-shot convenience functions, re-submitted as a typed-input PR (the
earlier `encode_rgba8_bytes(&[u8], width, height)` / `decode_rgba8` pair was
removed from `main` in the immediately preceding commit, pending this redesign).

## What changed

- **`encode(img: zenpixels::PixelSlice<'_>) -> Result<Vec<u8>>`** — the encode
  one-shot now takes a self-describing `zenpixels::PixelSlice`. The pixel
  **format, dimensions, and row stride ride with the pixels**, so there are no
  redundant `width`/`height` arguments to keep in sync and the whole
  buffer-length-mismatch class of bug is gone — strided slices just work. It
  wraps the default `PngEncoderConfig` → job → encode path and accepts any
  `PixelSlice` format (RGBA8, RGB8, grayscale, 16-bit, …), not just RGBA8.
- **`decode_rgba8(&[u8]) -> Result<(Vec<u8>, u32, u32)>`** — unchanged. Bytes are
  already self-describing, so this signature was fine as-is; it decodes any PNG
  to packed RGBA8 + dimensions (normalizing grayscale / indexed / RGB / 16-bit).

Per the zencodec convention, `zenpixels` types are **not** re-exported — callers
`use zenpixels::PixelSlice`.

Both are purely additive wrappers over the existing builder/config path; the full
power API (custom filter/effort, metadata, 16-bit, cancellation) is unchanged.
README quick-start leads with these, each fn carries the round-trip as a runnable
doctest, and the public-api snapshot + `README.crates.md` are regenerated.

Mirrors the same shape as imazen/zenresize PR #14 (typed input, fallible,
removed-from-main-first).

## Verification (local, via run-heavy)

- `cargo test --doc` — 4 passed, 0 failed (encode + decode_rgba8 round-trips)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt -p zenpng --check` — clean